### PR TITLE
Removing creation of topics in replicated vpcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.5.1] - SNAPSHOT
 ### Added
 - Updated `README` with Expedia Group stream registry announcement 
+- Removed the creation of topics in the VPCs where it is to be replicated
 
 ### Changed
 

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/service/impl/StreamServiceImpl.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/service/impl/StreamServiceImpl.java
@@ -162,12 +162,6 @@ public class StreamServiceImpl extends AbstractService implements StreamService 
         for (String vpc : vpcList) {
             upsertTopics(stream, vpc, isNewStream);
         }
-        if (replicatedVpcList != null && !replicatedVpcList.isEmpty()) {
-            log.info("creating topics for replicatedVpcList: {}", replicatedVpcList);
-            for (String vpc : replicatedVpcList) {
-                upsertTopics(stream, vpc, isNewStream);
-            }
-        }
     }
 
     private void upsertTopics(Stream stream, String vpc, boolean isNewStream) throws StreamCreationException, ClusterNotFoundException {


### PR DESCRIPTION
# stream-registry PR

Topics are being created in the VPCs where streams are to be replicated, with no added benefit of having created them in the first place. Stream Replicator application is responsible for creating topics in those VPCs and Stream Registry should not do anything about them.

### Deleted
* The creation of topics in the VPCs where the stream is to be replicated


# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
