### PR TITLE
adding the forceSync flag for handling conflicting topic configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.5.1] - SNAPSHOT
 ### Added
 - Updated `README` with Expedia Group stream registry announcement (#155) 
+- Added the `forceSync` flag for handling conflicting topic configs while upserting stream (#114)
 
 ### Changed
 - Updated mkdocs.yml to `expediagroup` (#168)

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/model/Stream.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/model/Stream.java
@@ -133,6 +133,13 @@ public class Stream {
     @ApiModelProperty(example = "3")
     int replicationFactor;
 
+    /**
+     * Should the provided topic config be forcibly synced with the existing, underlying topic (if not the same)?
+     */
+    @ApiModelProperty(example = "false")
+    @Builder.Default
+    Boolean forceSync = false;
+
     @JsonPOJOBuilder(withPrefix = "")
     public static final class StreamBuilder {
     }

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/provider/InfraManager.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/provider/InfraManager.java
@@ -98,11 +98,12 @@ public interface InfraManager {
      * @param replicationFactor replicationFactor for each of those topics
      * @param topicConfig topic config to use for each of these topics
      * @param isNewStream whether or not this invocation results from existing or new stream in stream registry.
+     * @param forceSync whether or not the provided topic config be forcibly synced with the existing, underlying topic (if not the same).
      * @throws StreamCreationException  when Stream could not be created in the underlying infrastructure for following reasons
      *      a) Input Configs and the existing configs does not match for a new Stream on-boarded to StreamRegistry,
      *      but already available in the infrastructure.
      */
-    void upsertTopics(Collection<String> topics, int partitions, int replicationFactor, Properties topicConfig, boolean isNewStream)
+    void upsertTopics(Collection<String> topics, int partitions, int replicationFactor, Properties topicConfig, boolean isNewStream, boolean forceSync)
         throws StreamCreationException;
 
 }

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/service/impl/StreamServiceImpl.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/service/impl/StreamServiceImpl.java
@@ -182,7 +182,7 @@ public class StreamServiceImpl extends AbstractService implements StreamService 
         topicConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
         topicConfig.put(KafkaProducerConfig.ZOOKEEPER_QUORUM, zkConnect);
 
-        infraManager.upsertTopics(Collections.singleton(stream.getName()), stream.getPartitions(), stream.getReplicationFactor(), topicConfig, isNewStream);
+        infraManager.upsertTopics(Collections.singleton(stream.getName()), stream.getPartitions(), stream.getReplicationFactor(), topicConfig, isNewStream, stream.getForceSync());
         log.info("Topic {} created/updated at {}", stream.getName(), bootstrapServer);
     }
 

--- a/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/InfraManagerImplStub.java
+++ b/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/InfraManagerImplStub.java
@@ -49,7 +49,7 @@ public class InfraManagerImplStub implements InfraManager {
     }
 
     @Override
-    public void upsertTopics(Collection<String> topics, int partitions, int replicationFactor, Properties topicConfig, boolean isNewStream) {
+    public void upsertTopics(Collection<String> topics, int partitions, int replicationFactor, Properties topicConfig, boolean isNewStream, boolean forceSync) {
     }
 
     @Override

--- a/infra-provider-kafka/src/main/java/com/homeaway/streamplatform/streamregistry/provider/impl/KafkaInfraManager.java
+++ b/infra-provider-kafka/src/main/java/com/homeaway/streamplatform/streamregistry/provider/impl/KafkaInfraManager.java
@@ -257,7 +257,7 @@ public class KafkaInfraManager implements InfraManager {
             // Added a forceSync=true flag, ignoring any user provided info, and only updating SR with the underlying settings (#114)
             if (forceSync) {
                 // NOTHING TO DO!
-                log.info("topic config mismatch for {} ignored.", topic);
+                log.info("topic config mismatch for {} ignored. Input config={}, actual (retained) config={}", topic, topicConfigMap, actualTopicConfig);
                 continue;
             }
             if (isStreamNotAvailableInStreamRegistryDB) {

--- a/infra-provider-kafka/src/test/java/com/homeaway/streamplatform/streamregistry/provider/impl/KafkaInfraManagerTest.java
+++ b/infra-provider-kafka/src/test/java/com/homeaway/streamplatform/streamregistry/provider/impl/KafkaInfraManagerTest.java
@@ -207,7 +207,7 @@ public class KafkaInfraManagerTest {
 
         // Existing Stream, but PROPS match!! should not have an exception
         Properties prop = new Properties();
-        prop.put("max.message.bytes", "64000");
+        prop.put("MAX_MESSAGE_BYTES_CONFIG", "64000");
         kafkaManagerSpy.upsertTopics(Collections.singleton(TOPIC), PARTITIONS, REPLICATION_FACTOR, prop, true, true);
 
         // verify change topic DOES NOT HAPPEN because props match

--- a/infra-provider-kafka/src/test/java/com/homeaway/streamplatform/streamregistry/provider/impl/KafkaInfraManagerTest.java
+++ b/infra-provider-kafka/src/test/java/com/homeaway/streamplatform/streamregistry/provider/impl/KafkaInfraManagerTest.java
@@ -207,7 +207,7 @@ public class KafkaInfraManagerTest {
 
         // Existing Stream, but PROPS match!! should not have an exception
         Properties prop = new Properties();
-        prop.put("k1", "v1");
+        prop.put("max.message.bytes", "64000");
         kafkaManagerSpy.upsertTopics(Collections.singleton(TOPIC), PARTITIONS, REPLICATION_FACTOR, prop, true, true);
 
         // verify change topic DOES NOT HAPPEN because props match

--- a/schema-library-events/src/main/avro/stream.avdl
+++ b/schema-library-events/src/main/avro/stream.avdl
@@ -196,6 +196,12 @@ protocol StreamRegistryProtocol {
     * Replication Factor
     */
     int replicationFactor = 3;
+
+    /**
+    * Should the provided topic config be forcibly synced with the existing, underlying topic (if not the same)?
+    */
+    boolean forceSync = false;
+
   }
 
   record AvroStreamKey {


### PR DESCRIPTION
# stream-registry PR

Adding flag to provide an option to override user-provided topic config in case of already existing conflicting configs on the underlying brokers (https://github.com/ExpediaGroup/stream-registry/issues/114)

- Fixes #114 

### Added
* Boolean flag `forceSync` which can be set by a user while upserting a stream to override the provided topic configs in the stream and continue using the existing topic configs on the brokers.

# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
