### PR TITLE
Changing wait timer to 200 ms (fixing build)

### DIFF
--- a/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/BaseResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/BaseResourceIT.java
@@ -131,7 +131,7 @@ public class BaseResourceIT {
     // TODO: Make resources "consistent" by having all writes (mutations)
     //     - wait some timeout period for the processor to process
     //     - THIS IS A TEMPORARY WORKAROUND for now... centralizing here so that we can soon remove it (#116)
-    protected static final int TEST_SLEEP_WAIT_MS = 80;
+    protected static final int TEST_SLEEP_WAIT_MS = 200;
 
     protected static ManagedKStreams managedKStreams;
 


### PR DESCRIPTION
# stream-registry PR

Increasing the wait time in test suite to ensure that the underlying data store catches up with commits.

### Changed
* The wait timer in test suite increased to 200 ms.

# PR Checklist Forms

- [x] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
