### PR TITLE
Removal of redundant topic creation in replicated VPCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Updated `README` with Expedia Group stream registry announcement (#155) 
 - Increasing the WAIT time to 100ms in test cases to allow the underlying datastore to sync with the commits.
+- Removed the creation of topics in the VPCs where it is to be replicated
 
 ### Changed
 - Updated mkdocs.yml to `expediagroup` (#168)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Updated `README` with Expedia Group stream registry announcement (#155) 
 - Increasing the WAIT time to 100ms in test cases to allow the underlying datastore to sync with the commits.
-- Removed the creation of topics in the VPCs where it is to be replicated
+- Removed a redundant topic creation on the replicated VPCs.
 
 ### Changed
 - Updated mkdocs.yml to `expediagroup` (#168)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Updated `README` with Expedia Group stream registry announcement (#155) 
 - Increasing the WAIT time to 100ms in test cases to allow the underlying datastore to sync with the commits.
-- Removed a redundant topic creation on the replicated VPCs.
 
 ### Changed
 - Updated mkdocs.yml to `expediagroup` (#168)
+
+### Removed
+- Removed redundant topic creation in the replicated VPCs.
 
 ## [0.5.0] - 20190412
 ### Added

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/service/impl/StreamServiceImpl.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/service/impl/StreamServiceImpl.java
@@ -157,7 +157,6 @@ public class StreamServiceImpl extends AbstractService implements StreamService 
      */
     private void verifyAndUpsertTopics(Stream stream, boolean isNewStream) throws StreamCreationException, ClusterNotFoundException {
         List<String> vpcList = stream.getVpcList();
-        List<String> replicatedVpcList = stream.getReplicatedVpcList();
         log.info("creating topics for vpcList: {}", vpcList);
         for (String vpc : vpcList) {
             upsertTopics(stream, vpc, isNewStream);

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/service/impl/StreamServiceImpl.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/service/impl/StreamServiceImpl.java
@@ -162,12 +162,6 @@ public class StreamServiceImpl extends AbstractService implements StreamService 
         for (String vpc : vpcList) {
             upsertTopics(stream, vpc, isNewStream);
         }
-        if (replicatedVpcList != null && !replicatedVpcList.isEmpty()) {
-            log.info("creating topics for replicatedVpcList: {}", replicatedVpcList);
-            for (String vpc : replicatedVpcList) {
-                upsertTopics(stream, vpc, isNewStream);
-            }
-        }
     }
 
     private void upsertTopics(Stream stream, String vpc, boolean isNewStream) throws StreamCreationException, ClusterNotFoundException {

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/service/impl/StreamServiceImpl.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/service/impl/StreamServiceImpl.java
@@ -156,6 +156,8 @@ public class StreamServiceImpl extends AbstractService implements StreamService 
      * @param stream the stream that will be used to verify and/or upsert topics to
      */
     private void verifyAndUpsertTopics(Stream stream, boolean isNewStream) throws StreamCreationException, ClusterNotFoundException {
+        // Only pay attention to "primary" (not replacted) vpcList. That way if replicated targets are different
+        // we do not get "stuck". Refer issues (#52) and (#114) for context.
         List<String> vpcList = stream.getVpcList();
         log.info("creating topics for vpcList: {}", vpcList);
         for (String vpc : vpcList) {


### PR DESCRIPTION
# stream-registry PR

Topics are being created in the VPCs where streams are to be replicated, with no added benefit of having created them in the first place.

### Deleted
* The creation of topics in the VPCs where the stream is to be replicated


# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 