### PR TITLE
Dockerize #181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * New internal model with service, handler and repository layers. 
 * Domain, Schema & Stream entities.
 * Reference GraphQL client.
+* Dockerfile :whale:   
 
 ### Changed
 - Changed groupId to `com.expediagroup.streamplatform`

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,14 @@
+ARG BASE_CONTAINER=openjdk:11
+FROM $BASE_CONTAINER
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+EXPOSE 8080
+
+COPY target/lib /usr/share/stream-registry/lib
+ARG JAR_FILE
+COPY target/${JAR_FILE} /usr/share/stream-registry/stream-registry.jar
+ARG MAIN_CLASS_ARG
+ENV MAIN_CLASS=$MAIN_CLASS_ARG
+
+ARG CONTEXT_DIR
+COPY ${CONTEXT_DIR}/docker-entrypoint.sh /

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -38,6 +38,59 @@
     </dependency>
   </dependencies>
 
-  <!--  TODO jib-->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-api</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>com.expediagroup.streamplatform</groupId>
+                  <artifactId>stream-registry-graphql-api</artifactId>
+                  <version>${project.version}</version>
+                  <includes>*.graphql</includes>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+          <execution>
+            <id>prepare-classpath</id>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <overWriteReleases>false</overWriteReleases>
+              <includeScope>runtime</includeScope>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <classpathPrefix>lib/</classpathPrefix>
+              <mainClass>${main.class}</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/app/src/main/docker/docker-entrypoint.sh
+++ b/app/src/main/docker/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Which java to use
+if [ -z "$JAVA_HOME" ]; then
+  JAVA="java"
+else
+  JAVA="$JAVA_HOME/bin/java"
+fi
+
+# Generic jvm settings you want to add
+if [ -z "$JAVA_OPTS" ]; then
+  JAVA_OPTS=""
+fi
+
+# Memory options
+if [ -z "$JAVA_HEAP_OPTS" ]; then
+  JAVA_HEAP_OPTS="-Xmx256M"
+fi
+
+# JVM performance options
+if [ -z "$JVM_PERFORMANCE_OPTS" ]; then
+  JVM_PERFORMANCE_OPTS="-server -Djava.awt.headless=true -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent"
+fi
+
+# Explicitly setting the classpath allows for plugins to be added later
+CLASSPATH="/usr/share/stream-registry/stream-registry.jar:/usr/share/stream-registry/lib/*.jar"
+exec $JAVA -cp $CLASSPATH \
+    $JAVA_HEAP_OPTS $JVM_PERFORMANCE_OPTS $JAVA_OPTS \
+    $MAIN_CLASS

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>11</java.version>
 
+    <main.class>com.expediagroup.streamplatform.streamregistry.app.StreamRegistryApp</main.class>
+
     <avro.version>1.8.2</avro.version>
     <confluent.version>5.2.1</confluent.version>
     <guava.version>27.1-jre</guava.version>
@@ -158,11 +160,25 @@
   </dependencyManagement>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>${maven-dependency-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>${maven-jar-plugin.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>${maven-dependency-plugin.version}</version>
         <executions>
           <execution>
             <id>unpack</id>
@@ -319,7 +335,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>${maven-jar-plugin.version}</version>
         <configuration>
           <archive>
             <manifestEntries>
@@ -366,6 +381,56 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>docker</id>
+      <activation>
+        <file>
+          <exists>Dockerfile</exists>
+        </file>
+      </activation>
+      <properties>
+        <docker.repo/>
+        <docker.image.name>stream-registry</docker.image.name>
+        <docker.image.base>openjdk:11</docker.image.base>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <version>1.4.10</version>
+            <executions>
+              <execution>
+                <id>default</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <repository>${docker.repo}${docker.image.name}</repository>
+                  <tag>${project.version}</tag>
+                  <buildArgs>
+                    <BASE_CONTAINER>${docker.image.base}</BASE_CONTAINER>
+                    <CONTEXT_DIR>src/main/docker</CONTEXT_DIR>
+                    <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+                    <MAIN_CLASS_ARG>${main.class}</MAIN_CLASS_ARG>
+                  </buildArgs>
+                </configuration>
+              </execution>
+              <execution>
+                <id>tag-latest</id>
+                <goals>
+                  <goal>tag</goal>
+                </goals>
+                <configuration>
+                  <repository>${docker.repo}${docker.image.name}</repository>
+                  <tag>latest</tag>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>source-and-javadoc</id>
       <activation>


### PR DESCRIPTION
# stream-registry PR

Same commits as #181 that was (minimally) Dockerized

One commit -  4a7670b

### Added
* Docker maven plugins w/ profile 
* Dockerfile to `app` module; Dependency plugin to copy over api graphql file, otherwise got errors about file not on the app's classpath. 

### Changed
* `maven-jar-plugin` to add classpath and main-class entries in `app`

# To build

For internal usage

`./mvnw clean package -DskipTests -Ddocker.repo=<docker.repo>/<owner>/` (trailing slash is important) && `docker push <docker.repo>/<owner>/stream-registry` (until the plugin is setup to push)

by default, just builds local image `stream-registry` 

# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
