### PR TITLE
Split all Upserts in the API to Insert and Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Reference GraphQL client.
 
 ### Changed
+- Seperated Upsert into Insert and Update _at the API layer only_
 - Converted project into spring boot starter
 - 1.0.0-SNAPSHOT -> 0.7.0-SNAPSHOT
 - Changed groupId to `com.expediagroup.streamplatform`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Reference GraphQL client.
 
 ### Changed
-- Separated Upsert into Insert and Update _at the API layer only_
+- Separated Upsert into Create and Update _at the API layer only_
 - Converted project into spring boot starter
 - 1.0.0-SNAPSHOT -> 0.7.0-SNAPSHOT
 - Changed groupId to `com.expediagroup.streamplatform`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Reference GraphQL client.
 
 ### Changed
-- Seperated Upsert into Insert and Update _at the API layer only_
+- Separated Upsert into Insert and Update _at the API layer only_
 - Converted project into spring boot starter
 - 1.0.0-SNAPSHOT -> 0.7.0-SNAPSHOT
 - Changed groupId to `com.expediagroup.streamplatform`

--- a/graphql-api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/resolver/Mutation.java
+++ b/graphql-api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/resolver/Mutation.java
@@ -40,7 +40,7 @@ public class Mutation implements GraphQLMutationResolver {
   private final Service<Schema, Schema.Key> schemaService;
   private final Service<Stream, Stream.Key> streamService;
 
-  public boolean insertDomain(
+  public boolean createDomain(
       String name,
       String description,
       Map<String, String> tags,
@@ -78,7 +78,7 @@ public class Mutation implements GraphQLMutationResolver {
     return true;
   }
 
-  public boolean insertSchema(
+  public boolean createSchema(
       String name,
       String description,
       Map<String, String> tags,
@@ -123,7 +123,7 @@ public class Mutation implements GraphQLMutationResolver {
     return true;
   }
 
-  public boolean insertStream(
+  public boolean createStream(
       String name,
       String description,
       Map<String, String> tags,
@@ -183,7 +183,7 @@ public class Mutation implements GraphQLMutationResolver {
     return true;
   }
 
-  public boolean insertZone(
+  public boolean createZone(
       String name,
       String description,
       Map<String, String> tags,
@@ -211,7 +211,7 @@ public class Mutation implements GraphQLMutationResolver {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public boolean insertInfrastructure(
+  public boolean createInfrastructure(
       String name,
       String description,
       Map<String, String> tags,
@@ -242,7 +242,7 @@ public class Mutation implements GraphQLMutationResolver {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public boolean insertProducer(
+  public boolean createProducer(
       String name,
       String description,
       Map<String, String> tags,
@@ -276,7 +276,7 @@ public class Mutation implements GraphQLMutationResolver {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public boolean insertConsumer(
+  public boolean createConsumer(
       String name,
       String description,
       Map<String, String> tags,
@@ -310,7 +310,7 @@ public class Mutation implements GraphQLMutationResolver {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public boolean insertStreamBinding(
+  public boolean createStreamBinding(
       String name,
       String description,
       Map<String, String> tags,
@@ -344,7 +344,7 @@ public class Mutation implements GraphQLMutationResolver {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public boolean insertProducerBinding(
+  public boolean createProducerBinding(
       String name,
       String description,
       Map<String, String> tags,
@@ -378,7 +378,7 @@ public class Mutation implements GraphQLMutationResolver {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public boolean insertConsumerBinding(
+  public boolean createConsumerBinding(
       String name,
       String description,
       Map<String, String> tags,

--- a/graphql-api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/resolver/Mutation.java
+++ b/graphql-api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/resolver/Mutation.java
@@ -40,7 +40,25 @@ public class Mutation implements GraphQLMutationResolver {
   private final Service<Schema, Schema.Key> schemaService;
   private final Service<Stream, Stream.Key> streamService;
 
-  public boolean upsertDomain(
+  public boolean insertDomain(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration) {
+    return upsertDomain(name, description, tags, type, configuration);
+  }
+
+  public boolean updateDomain(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration) {
+    return upsertDomain(name, description, tags, type, configuration);
+  }
+
+  private boolean upsertDomain(
       String name,
       String description,
       Map<String, String> tags,
@@ -60,7 +78,27 @@ public class Mutation implements GraphQLMutationResolver {
     return true;
   }
 
-  public boolean upsertSchema(
+  public boolean insertSchema(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration,
+      String domain) {
+    return upsertSchema(name,description,tags,type,configuration,domain);
+  }
+
+  public boolean updateSchema(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration,
+      String domain) {
+    return upsertSchema(name,description,tags,type,configuration,domain);
+  }
+
+  private boolean upsertSchema(
       String name,
       String description,
       Map<String, String> tags,
@@ -85,7 +123,31 @@ public class Mutation implements GraphQLMutationResolver {
     return true;
   }
 
-  public boolean upsertStream(
+  public boolean insertStream(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration,
+      String domain,
+      Integer version,
+      GraphQLSchema.Key schema) {
+    return upsertStream(name,description,tags,type,configuration,domain,version,schema);
+  }
+
+  public boolean updateStream(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration,
+      String domain,
+      Integer version,
+      GraphQLSchema.Key schema) {
+    return upsertStream(name,description,tags,type,configuration,domain,version,schema);
+  }
+
+  private boolean upsertStream(
       String name,
       String description,
       Map<String, String> tags,
@@ -121,7 +183,25 @@ public class Mutation implements GraphQLMutationResolver {
     return true;
   }
 
-  public boolean upsertZone(
+  public boolean insertZone(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration) {
+    return updateZone(name,description,tags,type,configuration);
+  }
+
+  public boolean updateZone(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration) {
+    return updateZone(name,description,tags,type,configuration);
+  }
+
+  private boolean upsertZone(
       String name,
       String description,
       Map<String, String> tags,
@@ -131,7 +211,27 @@ public class Mutation implements GraphQLMutationResolver {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public boolean upsertInfrastructure(
+  public boolean insertInfrastructure(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration,
+      String zone) {
+    return upsertInfrastructure(name,description,tags,type,configuration,zone);
+  }
+
+  public boolean updateInfrastructure(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration,
+      String zone) {
+    return upsertInfrastructure(name,description,tags,type,configuration,zone);
+  }
+
+  private boolean upsertInfrastructure(
       String name,
       String description,
       Map<String, String> tags,
@@ -142,7 +242,29 @@ public class Mutation implements GraphQLMutationResolver {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public boolean upsertProducer(
+  public boolean insertProducer(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration,
+      GraphQLStream.Key stream,
+      List<String> zones) {
+    return upsertProducer(name,description,tags,type,configuration,stream,zones);
+  }
+
+  public boolean updateProducer(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration,
+      GraphQLStream.Key stream,
+      List<String> zones) {
+    return upsertProducer(name,description,tags,type,configuration,stream,zones);
+  }
+
+  private boolean upsertProducer(
       String name,
       String description,
       Map<String, String> tags,
@@ -154,7 +276,29 @@ public class Mutation implements GraphQLMutationResolver {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public boolean upsertConsumer(
+  public boolean insertConsumer(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration,
+      GraphQLStream.Key stream,
+      List<String> zones) {
+    return upsertConsumer(name,description,tags,type,configuration,stream,zones);
+  }
+
+  public boolean updateConsumer(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration,
+      GraphQLStream.Key stream,
+      List<String> zones) {
+    return upsertConsumer(name,description,tags,type,configuration,stream,zones);
+  }
+
+  private boolean upsertConsumer(
       String name,
       String description,
       Map<String, String> tags,
@@ -166,7 +310,29 @@ public class Mutation implements GraphQLMutationResolver {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public boolean upsertStreamBinding(
+  public boolean insertStreamBinding(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration,
+      GraphQLStream.Key stream,
+      GraphQLInfrastructure.Key infrastructure) {
+    return upsertStreamBinding(name,description,tags,type,configuration,stream,infrastructure);
+  }
+
+  public boolean updateStreamBinding(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration,
+      GraphQLStream.Key stream,
+      GraphQLInfrastructure.Key infrastructure) {
+    return upsertStreamBinding(name,description,tags,type,configuration,stream,infrastructure);
+  }
+
+  private boolean upsertStreamBinding(
       String name,
       String description,
       Map<String, String> tags,
@@ -178,7 +344,29 @@ public class Mutation implements GraphQLMutationResolver {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public boolean upsertProducerBinding(
+  public boolean insertProducerBinding(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration,
+      String producer,
+      List<String> zones) {
+    return upsertProducerBinding(name,description,tags,type,configuration,producer,zones);
+  }
+
+  public boolean updateProducerBinding(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration,
+      String producer,
+      List<String> zones) {
+    return upsertProducerBinding(name,description,tags,type,configuration,producer,zones);
+  }
+
+  private boolean upsertProducerBinding(
       String name,
       String description,
       Map<String, String> tags,
@@ -190,7 +378,29 @@ public class Mutation implements GraphQLMutationResolver {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public boolean upsertConsumerBinding(
+  public boolean insertConsumerBinding(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration,
+      String consumer,
+      List<String> zones) {
+    return upsertConsumerBinding(name,description,tags,type,configuration,consumer,zones);
+  }
+
+  public boolean updateConsumerBinding(
+      String name,
+      String description,
+      Map<String, String> tags,
+      String type,
+      ObjectNode configuration,
+      String consumer,
+      List<String> zones) {
+    return upsertConsumerBinding(name,description,tags,type,configuration,consumer,zones);
+  }
+
+  private boolean upsertConsumerBinding(
       String name,
       String description,
       Map<String, String> tags,

--- a/graphql-api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/resolver/Mutation.java
+++ b/graphql-api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/resolver/Mutation.java
@@ -85,7 +85,7 @@ public class Mutation implements GraphQLMutationResolver {
       String type,
       ObjectNode configuration,
       String domain) {
-    return upsertSchema(name,description,tags,type,configuration,domain);
+    return upsertSchema(name, description, tags, type, configuration, domain);
   }
 
   public boolean updateSchema(
@@ -95,7 +95,7 @@ public class Mutation implements GraphQLMutationResolver {
       String type,
       ObjectNode configuration,
       String domain) {
-    return upsertSchema(name,description,tags,type,configuration,domain);
+    return upsertSchema(name, description, tags, type, configuration, domain);
   }
 
   private boolean upsertSchema(
@@ -132,7 +132,7 @@ public class Mutation implements GraphQLMutationResolver {
       String domain,
       Integer version,
       GraphQLSchema.Key schema) {
-    return upsertStream(name,description,tags,type,configuration,domain,version,schema);
+    return upsertStream(name, description, tags, type, configuration, domain, version, schema);
   }
 
   public boolean updateStream(
@@ -144,7 +144,7 @@ public class Mutation implements GraphQLMutationResolver {
       String domain,
       Integer version,
       GraphQLSchema.Key schema) {
-    return upsertStream(name,description,tags,type,configuration,domain,version,schema);
+    return upsertStream(name, description, tags, type, configuration, domain, version, schema);
   }
 
   private boolean upsertStream(
@@ -189,7 +189,7 @@ public class Mutation implements GraphQLMutationResolver {
       Map<String, String> tags,
       String type,
       ObjectNode configuration) {
-    return updateZone(name,description,tags,type,configuration);
+    return updateZone(name, description, tags, type, configuration);
   }
 
   public boolean updateZone(
@@ -198,7 +198,7 @@ public class Mutation implements GraphQLMutationResolver {
       Map<String, String> tags,
       String type,
       ObjectNode configuration) {
-    return updateZone(name,description,tags,type,configuration);
+    return updateZone(name, description, tags, type, configuration);
   }
 
   private boolean upsertZone(
@@ -218,7 +218,7 @@ public class Mutation implements GraphQLMutationResolver {
       String type,
       ObjectNode configuration,
       String zone) {
-    return upsertInfrastructure(name,description,tags,type,configuration,zone);
+    return upsertInfrastructure(name, description, tags, type, configuration, zone);
   }
 
   public boolean updateInfrastructure(
@@ -228,7 +228,7 @@ public class Mutation implements GraphQLMutationResolver {
       String type,
       ObjectNode configuration,
       String zone) {
-    return upsertInfrastructure(name,description,tags,type,configuration,zone);
+    return upsertInfrastructure(name, description, tags, type, configuration, zone);
   }
 
   private boolean upsertInfrastructure(
@@ -250,7 +250,7 @@ public class Mutation implements GraphQLMutationResolver {
       ObjectNode configuration,
       GraphQLStream.Key stream,
       List<String> zones) {
-    return upsertProducer(name,description,tags,type,configuration,stream,zones);
+    return upsertProducer(name, description, tags, type, configuration, stream, zones);
   }
 
   public boolean updateProducer(
@@ -261,7 +261,7 @@ public class Mutation implements GraphQLMutationResolver {
       ObjectNode configuration,
       GraphQLStream.Key stream,
       List<String> zones) {
-    return upsertProducer(name,description,tags,type,configuration,stream,zones);
+    return upsertProducer(name, description, tags, type, configuration, stream, zones);
   }
 
   private boolean upsertProducer(
@@ -284,7 +284,7 @@ public class Mutation implements GraphQLMutationResolver {
       ObjectNode configuration,
       GraphQLStream.Key stream,
       List<String> zones) {
-    return upsertConsumer(name,description,tags,type,configuration,stream,zones);
+    return upsertConsumer(name, description, tags, type, configuration, stream, zones);
   }
 
   public boolean updateConsumer(
@@ -295,7 +295,7 @@ public class Mutation implements GraphQLMutationResolver {
       ObjectNode configuration,
       GraphQLStream.Key stream,
       List<String> zones) {
-    return upsertConsumer(name,description,tags,type,configuration,stream,zones);
+    return upsertConsumer(name, description, tags, type, configuration, stream, zones);
   }
 
   private boolean upsertConsumer(
@@ -318,7 +318,7 @@ public class Mutation implements GraphQLMutationResolver {
       ObjectNode configuration,
       GraphQLStream.Key stream,
       GraphQLInfrastructure.Key infrastructure) {
-    return upsertStreamBinding(name,description,tags,type,configuration,stream,infrastructure);
+    return upsertStreamBinding(name, description, tags, type, configuration, stream, infrastructure);
   }
 
   public boolean updateStreamBinding(
@@ -329,7 +329,7 @@ public class Mutation implements GraphQLMutationResolver {
       ObjectNode configuration,
       GraphQLStream.Key stream,
       GraphQLInfrastructure.Key infrastructure) {
-    return upsertStreamBinding(name,description,tags,type,configuration,stream,infrastructure);
+    return upsertStreamBinding(name, description, tags, type, configuration, stream, infrastructure);
   }
 
   private boolean upsertStreamBinding(
@@ -352,7 +352,7 @@ public class Mutation implements GraphQLMutationResolver {
       ObjectNode configuration,
       String producer,
       List<String> zones) {
-    return upsertProducerBinding(name,description,tags,type,configuration,producer,zones);
+    return upsertProducerBinding(name, description, tags, type, configuration, producer, zones);
   }
 
   public boolean updateProducerBinding(
@@ -363,7 +363,7 @@ public class Mutation implements GraphQLMutationResolver {
       ObjectNode configuration,
       String producer,
       List<String> zones) {
-    return upsertProducerBinding(name,description,tags,type,configuration,producer,zones);
+    return upsertProducerBinding(name, description, tags, type, configuration, producer, zones);
   }
 
   private boolean upsertProducerBinding(
@@ -386,7 +386,7 @@ public class Mutation implements GraphQLMutationResolver {
       ObjectNode configuration,
       String consumer,
       List<String> zones) {
-    return upsertConsumerBinding(name,description,tags,type,configuration,consumer,zones);
+    return upsertConsumerBinding(name, description, tags, type, configuration, consumer, zones);
   }
 
   public boolean updateConsumerBinding(
@@ -397,7 +397,7 @@ public class Mutation implements GraphQLMutationResolver {
       ObjectNode configuration,
       String consumer,
       List<String> zones) {
-    return upsertConsumerBinding(name,description,tags,type,configuration,consumer,zones);
+    return upsertConsumerBinding(name, description, tags, type, configuration, consumer, zones);
   }
 
   private boolean upsertConsumerBinding(

--- a/graphql-api/src/main/resources/stream-registry.graphql
+++ b/graphql-api/src/main/resources/stream-registry.graphql
@@ -237,7 +237,7 @@ type Query {
 }
 
 type Mutation {
-  insertDomain(
+  createDomain(
     name: String!
     description: String!
     tags: Tags!
@@ -251,7 +251,7 @@ type Mutation {
     type: String!
     configuration: Config!
   ): Boolean!
-  insertSchema(
+  createSchema(
     name: String!
     description: String!
     tags: Tags!
@@ -267,7 +267,7 @@ type Mutation {
     configuration: Config!
     domain: String!
   ): Boolean!
-  insertStream(
+  createStream(
     name: String!
     description: String!
     tags: Tags!
@@ -287,7 +287,7 @@ type Mutation {
     version: Int!
     schema: SchemaKeyInput!
   ): Boolean!
-  insertZone(
+  createZone(
     name: String!
     description: String!
     tags: Tags!
@@ -301,7 +301,7 @@ type Mutation {
     type: String!
     configuration: Config!
   ): Boolean!
-  insertInfrastructure(
+  createInfrastructure(
     name: String!
     description: String!
     tags: Tags!
@@ -317,7 +317,7 @@ type Mutation {
     configuration: Config!
     zone: String!
   ): Boolean!
-  insertProducer(
+  createProducer(
     name: String!
     description: String!
     tags: Tags!
@@ -335,7 +335,7 @@ type Mutation {
     stream: StreamKeyInput!
     zones: [String!]!
   ): Boolean!
-  insertConsumer(
+  createConsumer(
     name: String!
     description: String!
     tags: Tags!
@@ -353,7 +353,7 @@ type Mutation {
     stream: StreamKeyInput!
     zones: [String!]!
   ): Boolean!
-  insertStreamBinding(
+  createStreamBinding(
     name: String!
     description: String!
     tags: Tags!
@@ -371,7 +371,7 @@ type Mutation {
     stream: StreamKeyInput!
     infrastructure: InfrastructureKeyInput!
   ): Boolean!
-  insertProducerBinding(
+  createProducerBinding(
     name: String!
     description: String!
     tags: Tags!
@@ -389,7 +389,7 @@ type Mutation {
     producer: String!
     zones: [String!]!
   ): Boolean!
-  insertConsumerBinding(
+  createConsumerBinding(
     name: String!
     description: String!
     tags: Tags!

--- a/graphql-api/src/main/resources/stream-registry.graphql
+++ b/graphql-api/src/main/resources/stream-registry.graphql
@@ -237,14 +237,21 @@ type Query {
 }
 
 type Mutation {
-  upsertDomain(
+  insertDomain(
     name: String!
     description: String!
     tags: Tags!
     type: String!
     configuration: Config!
   ): Boolean!
-  upsertSchema(
+  updateDomain(
+    name: String!
+    description: String!
+    tags: Tags!
+    type: String!
+    configuration: Config!
+  ): Boolean!
+  insertSchema(
     name: String!
     description: String!
     tags: Tags!
@@ -252,7 +259,15 @@ type Mutation {
     configuration: Config!
     domain: String!
   ): Boolean!
-  upsertStream(
+  updateSchema(
+    name: String!
+    description: String!
+    tags: Tags!
+    type: String!
+    configuration: Config!
+    domain: String!
+  ): Boolean!
+  insertStream(
     name: String!
     description: String!
     tags: Tags!
@@ -262,14 +277,31 @@ type Mutation {
     version: Int!
     schema: SchemaKeyInput!
   ): Boolean!
-  upsertZone(
+  updateStream(
+    name: String!
+    description: String!
+    tags: Tags!
+    type: String!
+    configuration: Config!
+    domain: String!
+    version: Int!
+    schema: SchemaKeyInput!
+  ): Boolean!
+  insertZone(
     name: String!
     description: String!
     tags: Tags!
     type: String!
     configuration: Config!
   ): Boolean!
-  upsertInfrastructure(
+  updateZone(
+    name: String!
+    description: String!
+    tags: Tags!
+    type: String!
+    configuration: Config!
+  ): Boolean!
+  insertInfrastructure(
     name: String!
     description: String!
     tags: Tags!
@@ -277,7 +309,15 @@ type Mutation {
     configuration: Config!
     zone: String!
   ): Boolean!
-  upsertProducer(
+  updateInfrastructure(
+    name: String!
+    description: String!
+    tags: Tags!
+    type: String!
+    configuration: Config!
+    zone: String!
+  ): Boolean!
+  insertProducer(
     name: String!
     description: String!
     tags: Tags!
@@ -286,7 +326,7 @@ type Mutation {
     stream: StreamKeyInput!
     zones: [String!]!
   ): Boolean!
-  upsertConsumer(
+  updateProducer(
     name: String!
     description: String!
     tags: Tags!
@@ -295,7 +335,25 @@ type Mutation {
     stream: StreamKeyInput!
     zones: [String!]!
   ): Boolean!
-  upsertStreamBinding(
+  insertConsumer(
+    name: String!
+    description: String!
+    tags: Tags!
+    type: String!
+    configuration: Config!
+    stream: StreamKeyInput!
+    zones: [String!]!
+  ): Boolean!
+  updateConsumer(
+    name: String!
+    description: String!
+    tags: Tags!
+    type: String!
+    configuration: Config!
+    stream: StreamKeyInput!
+    zones: [String!]!
+  ): Boolean!
+  insertStreamBinding(
     name: String!
     description: String!
     tags: Tags!
@@ -304,7 +362,16 @@ type Mutation {
     stream: StreamKeyInput!
     infrastructure: InfrastructureKeyInput!
   ): Boolean!
-  upsertProducerBinding(
+  updateStreamBinding(
+    name: String!
+    description: String!
+    tags: Tags!
+    type: String!
+    configuration: Config!
+    stream: StreamKeyInput!
+    infrastructure: InfrastructureKeyInput!
+  ): Boolean!
+  insertProducerBinding(
     name: String!
     description: String!
     tags: Tags!
@@ -313,7 +380,25 @@ type Mutation {
     producer: String!
     zones: [String!]!
   ): Boolean!
-  upsertConsumerBinding(
+  updateProducerBinding(
+    name: String!
+    description: String!
+    tags: Tags!
+    type: String!
+    configuration: Config!
+    producer: String!
+    zones: [String!]!
+  ): Boolean!
+  insertConsumerBinding(
+    name: String!
+    description: String!
+    tags: Tags!
+    type: String!
+    configuration: Config!
+    consumer: String!
+    zones: [String!]!
+  ): Boolean!
+  updateConsumerBinding(
     name: String!
     description: String!
     tags: Tags!

--- a/graphql-api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/resolver/MutationTest.java
+++ b/graphql-api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/resolver/MutationTest.java
@@ -98,7 +98,7 @@ public class MutationTest {
 
   @Test
   public void upsertDomain() {
-    boolean result = underTest.insertDomain(
+    boolean result = underTest.createDomain(
         domain.getName(),
         domain.getDescription(),
         domain.getTags(),
@@ -112,7 +112,7 @@ public class MutationTest {
 
   @Test
   public void upsertSchema() {
-    boolean result = underTest.insertSchema(
+    boolean result = underTest.createSchema(
         schema.getName(),
         schema.getDescription(),
         schema.getTags(),
@@ -127,7 +127,7 @@ public class MutationTest {
 
   @Test
   public void upsertStream() {
-    boolean result = underTest.insertStream(
+    boolean result = underTest.createStream(
         stream.getName(),
         stream.getDescription(),
         stream.getTags(),

--- a/graphql-api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/resolver/MutationTest.java
+++ b/graphql-api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/resolver/MutationTest.java
@@ -98,7 +98,7 @@ public class MutationTest {
 
   @Test
   public void upsertDomain() {
-    boolean result = underTest.upsertDomain(
+    boolean result = underTest.insertDomain(
         domain.getName(),
         domain.getDescription(),
         domain.getTags(),
@@ -112,7 +112,7 @@ public class MutationTest {
 
   @Test
   public void upsertSchema() {
-    boolean result = underTest.upsertSchema(
+    boolean result = underTest.insertSchema(
         schema.getName(),
         schema.getDescription(),
         schema.getTags(),
@@ -127,7 +127,7 @@ public class MutationTest {
 
   @Test
   public void upsertStream() {
-    boolean result = underTest.upsertStream(
+    boolean result = underTest.insertStream(
         stream.getName(),
         stream.getDescription(),
         stream.getTags(),

--- a/graphql-client/src/main/graphql/client.graphql
+++ b/graphql-client/src/main/graphql/client.graphql
@@ -632,14 +632,14 @@ query ConsumerBindings(
   }
 }
 
-mutation UpsertDomain (
+mutation InsertDomain (
   $name: String!
   $description: String!
   $tags: Tags!
   $type: String!
   $configuration: Config!
 ){
-  upsertDomain(
+  insertDomain(
     name: $name
     description: $description
     tags: $tags
@@ -648,7 +648,23 @@ mutation UpsertDomain (
   )
 }
 
-mutation UpsertSchema (
+mutation UpdateDomain (
+  $name: String!
+  $description: String!
+  $tags: Tags!
+  $type: String!
+  $configuration: Config!
+){
+  updateDomain(
+    name: $name
+    description: $description
+    tags: $tags
+    type: $type
+    configuration: $configuration
+  )
+}
+
+mutation InsertSchema (
   $name: String!
   $description: String!
   $tags: Tags!
@@ -656,7 +672,7 @@ mutation UpsertSchema (
   $configuration: Config!
   $domain: String!
 ){
-  upsertSchema(
+  insertSchema(
     name: $name
     description: $description
     tags: $tags
@@ -666,7 +682,25 @@ mutation UpsertSchema (
   )
 }
 
-mutation UpsertStream (
+mutation UpdateSchema (
+  $name: String!
+  $description: String!
+  $tags: Tags!
+  $type: String!
+  $configuration: Config!
+  $domain: String!
+){
+  updateSchema(
+    name: $name
+    description: $description
+    tags: $tags
+    type: $type
+    configuration: $configuration
+    domain: $domain
+  )
+}
+
+mutation InsertStream (
   $name: String!
   $description: String!
   $tags: Tags!
@@ -676,7 +710,7 @@ mutation UpsertStream (
   $version: Int!
   $schema: SchemaKeyInput!
 ){
-  upsertStream(
+  insertStream(
     name: $name
     description: $description
     tags: $tags
@@ -688,14 +722,36 @@ mutation UpsertStream (
   )
 }
 
-mutation UpsertZone (
+mutation UpdateStream (
+  $name: String!
+  $description: String!
+  $tags: Tags!
+  $type: String!
+  $configuration: Config!
+  $domain: String!
+  $version: Int!
+  $schema: SchemaKeyInput!
+){
+  updateStream(
+    name: $name
+    description: $description
+    tags: $tags
+    type: $type
+    configuration: $configuration
+    domain: $domain
+    version: $version
+    schema: $schema
+  )
+}
+
+mutation InsertZone (
   $name: String!
   $description: String!
   $tags: Tags!
   $type: String!
   $configuration: Config!
 ){
-  upsertZone(
+  insertZone(
     name: $name
     description: $description
     tags: $tags
@@ -704,7 +760,23 @@ mutation UpsertZone (
   )
 }
 
-mutation UpsertInfrastructure (
+mutation UpdateZone (
+  $name: String!
+  $description: String!
+  $tags: Tags!
+  $type: String!
+  $configuration: Config!
+){
+  updateZone(
+    name: $name
+    description: $description
+    tags: $tags
+    type: $type
+    configuration: $configuration
+  )
+}
+
+mutation InsertInfrastructure (
   $name: String!
   $description: String!
   $tags: Tags!
@@ -712,7 +784,7 @@ mutation UpsertInfrastructure (
   $configuration: Config!
   $zone: String!
 ){
-  upsertInfrastructure(
+  insertInfrastructure(
     name: $name
     description: $description
     tags: $tags
@@ -722,7 +794,25 @@ mutation UpsertInfrastructure (
   )
 }
 
-mutation UpsertProducer (
+mutation UpdateInfrastructure (
+  $name: String!
+  $description: String!
+  $tags: Tags!
+  $type: String!
+  $configuration: Config!
+  $zone: String!
+){
+  updateInfrastructure(
+    name: $name
+    description: $description
+    tags: $tags
+    type: $type
+    configuration: $configuration
+    zone: $zone
+  )
+}
+
+mutation InsertProducer (
   $name: String!
   $description: String!
   $tags: Tags!
@@ -731,7 +821,7 @@ mutation UpsertProducer (
   $stream: StreamKeyInput!
   $zones: [String!]!
 ){
-  upsertProducer(
+  insertProducer(
     name: $name
     description: $description
     tags: $tags
@@ -742,7 +832,7 @@ mutation UpsertProducer (
   )
 }
 
-mutation UpsertConsumer (
+mutation UpdateProducer (
   $name: String!
   $description: String!
   $tags: Tags!
@@ -751,7 +841,7 @@ mutation UpsertConsumer (
   $stream: StreamKeyInput!
   $zones: [String!]!
 ){
-  upsertConsumer(
+  updateProducer(
     name: $name
     description: $description
     tags: $tags
@@ -762,7 +852,47 @@ mutation UpsertConsumer (
   )
 }
 
-mutation upsertStreamBinding (
+mutation InsertConsumer (
+  $name: String!
+  $description: String!
+  $tags: Tags!
+  $type: String!
+  $configuration: Config!
+  $stream: StreamKeyInput!
+  $zones: [String!]!
+){
+  insertConsumer(
+    name: $name
+    description: $description
+    tags: $tags
+    type: $type
+    configuration: $configuration
+    stream: $stream
+    zones: $zones
+  )
+}
+
+mutation UpdateConsumer (
+  $name: String!
+  $description: String!
+  $tags: Tags!
+  $type: String!
+  $configuration: Config!
+  $stream: StreamKeyInput!
+  $zones: [String!]!
+){
+  updateConsumer(
+    name: $name
+    description: $description
+    tags: $tags
+    type: $type
+    configuration: $configuration
+    stream: $stream
+    zones: $zones
+  )
+}
+
+mutation insertStreamBinding (
   $name: String!
   $description: String!
   $tags: Tags!
@@ -771,7 +901,7 @@ mutation upsertStreamBinding (
   $stream: StreamKeyInput!
   $infrastructure: InfrastructureKeyInput!
 ){
-  upsertStreamBinding(
+  insertStreamBinding(
     name: $name
     description: $description
     tags: $tags
@@ -782,7 +912,27 @@ mutation upsertStreamBinding (
   )
 }
 
-mutation UpsertProducerBinding (
+mutation updateStreamBinding (
+  $name: String!
+  $description: String!
+  $tags: Tags!
+  $type: String!
+  $configuration: Config!
+  $stream: StreamKeyInput!
+  $infrastructure: InfrastructureKeyInput!
+){
+  updateStreamBinding(
+    name: $name
+    description: $description
+    tags: $tags
+    type: $type
+    configuration: $configuration
+    stream: $stream
+    infrastructure: $infrastructure
+  )
+}
+
+mutation InsertProducerBinding (
   $name: String!
   $description: String!
   $tags: Tags!
@@ -791,7 +941,7 @@ mutation UpsertProducerBinding (
   $producer: String!
   $zones: [String!]!
 ){
-  upsertProducerBinding(
+  insertProducerBinding(
     name: $name
     description: $description
     tags: $tags
@@ -802,7 +952,27 @@ mutation UpsertProducerBinding (
   )
 }
 
-mutation UpsertConsumerBinding (
+mutation UpdateProducerBinding (
+  $name: String!
+  $description: String!
+  $tags: Tags!
+  $type: String!
+  $configuration: Config!
+  $producer: String!
+  $zones: [String!]!
+){
+  updateProducerBinding(
+    name: $name
+    description: $description
+    tags: $tags
+    type: $type
+    configuration: $configuration
+    producer: $producer
+    zones: $zones
+  )
+}
+
+mutation InsertConsumerBinding (
   $name: String!
   $description: String!
   $tags: Tags!
@@ -811,7 +981,27 @@ mutation UpsertConsumerBinding (
   $consumer: String!
   $zones: [String!]!
 ){
-  upsertConsumerBinding(
+  insertConsumerBinding(
+    name: $name
+    description: $description
+    tags: $tags
+    type: $type
+    configuration: $configuration
+    consumer: $consumer
+    zones: $zones
+  )
+}
+
+mutation UpdateConsumerBinding (
+  $name: String!
+  $description: String!
+  $tags: Tags!
+  $type: String!
+  $configuration: Config!
+  $consumer: String!
+  $zones: [String!]!
+){
+  updateConsumerBinding(
     name: $name
     description: $description
     tags: $tags

--- a/graphql-client/src/main/graphql/client.graphql
+++ b/graphql-client/src/main/graphql/client.graphql
@@ -632,14 +632,14 @@ query ConsumerBindings(
   }
 }
 
-mutation InsertDomain (
+mutation createDomain (
   $name: String!
   $description: String!
   $tags: Tags!
   $type: String!
   $configuration: Config!
 ){
-  insertDomain(
+  createDomain(
     name: $name
     description: $description
     tags: $tags
@@ -664,7 +664,7 @@ mutation UpdateDomain (
   )
 }
 
-mutation InsertSchema (
+mutation createSchema (
   $name: String!
   $description: String!
   $tags: Tags!
@@ -672,7 +672,7 @@ mutation InsertSchema (
   $configuration: Config!
   $domain: String!
 ){
-  insertSchema(
+  createSchema(
     name: $name
     description: $description
     tags: $tags
@@ -700,7 +700,7 @@ mutation UpdateSchema (
   )
 }
 
-mutation InsertStream (
+mutation createStream (
   $name: String!
   $description: String!
   $tags: Tags!
@@ -710,7 +710,7 @@ mutation InsertStream (
   $version: Int!
   $schema: SchemaKeyInput!
 ){
-  insertStream(
+  createStream(
     name: $name
     description: $description
     tags: $tags
@@ -744,14 +744,14 @@ mutation UpdateStream (
   )
 }
 
-mutation InsertZone (
+mutation createZone (
   $name: String!
   $description: String!
   $tags: Tags!
   $type: String!
   $configuration: Config!
 ){
-  insertZone(
+  createZone(
     name: $name
     description: $description
     tags: $tags
@@ -776,7 +776,7 @@ mutation UpdateZone (
   )
 }
 
-mutation InsertInfrastructure (
+mutation createInfrastructure (
   $name: String!
   $description: String!
   $tags: Tags!
@@ -784,7 +784,7 @@ mutation InsertInfrastructure (
   $configuration: Config!
   $zone: String!
 ){
-  insertInfrastructure(
+  createInfrastructure(
     name: $name
     description: $description
     tags: $tags
@@ -812,7 +812,7 @@ mutation UpdateInfrastructure (
   )
 }
 
-mutation InsertProducer (
+mutation createProducer (
   $name: String!
   $description: String!
   $tags: Tags!
@@ -821,7 +821,7 @@ mutation InsertProducer (
   $stream: StreamKeyInput!
   $zones: [String!]!
 ){
-  insertProducer(
+  createProducer(
     name: $name
     description: $description
     tags: $tags
@@ -852,7 +852,7 @@ mutation UpdateProducer (
   )
 }
 
-mutation InsertConsumer (
+mutation createConsumer (
   $name: String!
   $description: String!
   $tags: Tags!
@@ -861,7 +861,7 @@ mutation InsertConsumer (
   $stream: StreamKeyInput!
   $zones: [String!]!
 ){
-  insertConsumer(
+  createConsumer(
     name: $name
     description: $description
     tags: $tags
@@ -892,7 +892,7 @@ mutation UpdateConsumer (
   )
 }
 
-mutation insertStreamBinding (
+mutation createStreamBinding (
   $name: String!
   $description: String!
   $tags: Tags!
@@ -901,7 +901,7 @@ mutation insertStreamBinding (
   $stream: StreamKeyInput!
   $infrastructure: InfrastructureKeyInput!
 ){
-  insertStreamBinding(
+  createStreamBinding(
     name: $name
     description: $description
     tags: $tags
@@ -932,7 +932,7 @@ mutation updateStreamBinding (
   )
 }
 
-mutation InsertProducerBinding (
+mutation createProducerBinding (
   $name: String!
   $description: String!
   $tags: Tags!
@@ -941,7 +941,7 @@ mutation InsertProducerBinding (
   $producer: String!
   $zones: [String!]!
 ){
-  insertProducerBinding(
+  createProducerBinding(
     name: $name
     description: $description
     tags: $tags
@@ -972,7 +972,7 @@ mutation UpdateProducerBinding (
   )
 }
 
-mutation InsertConsumerBinding (
+mutation createConsumerBinding (
   $name: String!
   $description: String!
   $tags: Tags!
@@ -981,7 +981,7 @@ mutation InsertConsumerBinding (
   $consumer: String!
   $zones: [String!]!
 ){
-  insertConsumerBinding(
+  createConsumerBinding(
     name: $name
     description: $description
     tags: $tags

--- a/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/StreamRegistryIT.java
+++ b/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/StreamRegistryIT.java
@@ -42,8 +42,8 @@ import reactor.core.publisher.Mono;
 import com.expediagroup.streamplatform.streamregistry.app.StreamRegistryApp;
 import com.expediagroup.streamplatform.streamregistry.graphql.client.ConfigTypeAdapter;
 import com.expediagroup.streamplatform.streamregistry.graphql.client.DomainsQuery;
+import com.expediagroup.streamplatform.streamregistry.graphql.client.InsertDomainMutation;
 import com.expediagroup.streamplatform.streamregistry.graphql.client.TagsTypeAdapter;
-import com.expediagroup.streamplatform.streamregistry.graphql.client.UpsertDomainMutation;
 import com.expediagroup.streamplatform.streamregistry.graphql.client.reactor.ReactorApollo;
 import com.expediagroup.streamplatform.streamregistry.graphql.client.type.CustomType;
 
@@ -88,8 +88,8 @@ public class StreamRegistryIT {
         .addCustomTypeAdapter(CustomType.CONFIG, new ConfigTypeAdapter())
         .build();
 
-    Response<Optional<UpsertDomainMutation.Data>> mutation = ReactorApollo.from(
-        client.mutate(UpsertDomainMutation
+    Response<Optional<InsertDomainMutation.Data>> mutation = ReactorApollo.from(
+        client.mutate(InsertDomainMutation
             .builder()
             .name("domain")
             .description("description")
@@ -99,7 +99,7 @@ public class StreamRegistryIT {
             .build()))
         .block();
 
-    assertThat(mutation.data().get().isUpsertDomain(), is(true));
+    assertThat(mutation.data().get().isInsertDomain(), is(true));
 
     Mono.delay(Duration.ofSeconds(5)).block();
 

--- a/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/StreamRegistryIT.java
+++ b/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/StreamRegistryIT.java
@@ -41,8 +41,8 @@ import reactor.core.publisher.Mono;
 
 import com.expediagroup.streamplatform.streamregistry.app.StreamRegistryApp;
 import com.expediagroup.streamplatform.streamregistry.graphql.client.ConfigTypeAdapter;
+import com.expediagroup.streamplatform.streamregistry.graphql.client.CreateDomainMutation;
 import com.expediagroup.streamplatform.streamregistry.graphql.client.DomainsQuery;
-import com.expediagroup.streamplatform.streamregistry.graphql.client.InsertDomainMutation;
 import com.expediagroup.streamplatform.streamregistry.graphql.client.TagsTypeAdapter;
 import com.expediagroup.streamplatform.streamregistry.graphql.client.reactor.ReactorApollo;
 import com.expediagroup.streamplatform.streamregistry.graphql.client.type.CustomType;
@@ -88,8 +88,8 @@ public class StreamRegistryIT {
         .addCustomTypeAdapter(CustomType.CONFIG, new ConfigTypeAdapter())
         .build();
 
-    Response<Optional<InsertDomainMutation.Data>> mutation = ReactorApollo.from(
-        client.mutate(InsertDomainMutation
+    Response<Optional<CreateDomainMutation.Data>> mutation = ReactorApollo.from(
+        client.mutate(CreateDomainMutation
             .builder()
             .name("domain")
             .description("description")
@@ -99,7 +99,7 @@ public class StreamRegistryIT {
             .build()))
         .block();
 
-    assertThat(mutation.data().get().isInsertDomain(), is(true));
+    assertThat(mutation.data().get().isCreateDomain(), is(true));
 
     Mono.delay(Duration.ofSeconds(5)).block();
 


### PR DESCRIPTION
# stream-registry PR

_&lt;Split all Upserts in the API to Insert and Update&gt;_

### Added
* _&lt; Insert and Update&gt;_

### Changed
* _&lt;The Graphql internal and Client api definitions&gt;_
* _&lt;internally insert and update still defer to the upsert methods&gt;
