### PR TITLE
Vrbo master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.5.2] - SNAPSHOT
 ### Added
 
+### Changed
+- Fixed Consumers registering with invalid regions
+- Fixed Producers registering with invalid regions
+
 ## [0.5.1] - 20190627
 ### Added
 - Updated `README` with Expedia Group stream registry announcement (#155) 

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/service/impl/ConsumerServiceImpl.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/service/impl/ConsumerServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -127,8 +128,11 @@ public class ConsumerServiceImpl extends AbstractService implements StreamClient
         String region) throws RegionNotFoundException, ClusterNotFoundException {
         log.info("Registering new Consumer. Stream={} Consumer={} ; region={}", avroStream.getName(), consumerName, region);
 
-        if (!regionService.getSupportedRegions(avroStream.getTags().getHint()).contains(region))
-            throw new RegionNotFoundException(String.format("Region=%s is not supported for the Stream's hint=%s", region, avroStream.getTags().getHint()));
+        List<String> possibleRegions = Stream.concat(avroStream.getVpcList().stream(), avroStream.getReplicatedVpcList().stream())
+                .distinct()
+                .collect(Collectors.toList());
+        if (!possibleRegions.contains(region))
+            throw new RegionNotFoundException(String.format("Region=%s is not supported for regions=%s", region, possibleRegions));
 
         List<com.homeaway.digitalplatform.streamregistry.Consumer> listConsumers = avroStream.getConsumers();
         if (listConsumers == null) {

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/service/impl/ConsumerServiceImpl.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/service/impl/ConsumerServiceImpl.java
@@ -128,9 +128,13 @@ public class ConsumerServiceImpl extends AbstractService implements StreamClient
         String region) throws RegionNotFoundException, ClusterNotFoundException {
         log.info("Registering new Consumer. Stream={} Consumer={} ; region={}", avroStream.getName(), consumerName, region);
 
-        List<String> possibleRegions = Stream.concat(avroStream.getVpcList().stream(), avroStream.getReplicatedVpcList().stream())
-                .distinct()
-                .collect(Collectors.toList());
+        List<String> possibleRegions = avroStream.getVpcList();
+        if (avroStream.getReplicatedVpcList() != null) {
+            possibleRegions = Stream.concat(avroStream.getVpcList().stream(), avroStream.getReplicatedVpcList().stream())
+                    .distinct()
+                    .collect(Collectors.toList());
+        }
+
         if (!possibleRegions.contains(region))
             throw new RegionNotFoundException(String.format("Region=%s is not supported for regions=%s", region, possibleRegions));
 

--- a/core/src/main/java/com/homeaway/streamplatform/streamregistry/service/impl/ProducerServiceImpl.java
+++ b/core/src/main/java/com/homeaway/streamplatform/streamregistry/service/impl/ProducerServiceImpl.java
@@ -119,8 +119,9 @@ public class ProducerServiceImpl extends AbstractService implements StreamClient
     private Optional<com.homeaway.streamplatform.streamregistry.model.Producer> registerProducer(AvroStreamKey key, AvroStream avroStream, String producerName, String region)
             throws RegionNotFoundException, ClusterNotFoundException {
         log.info("Registering new Producer. Stream={} Producer={} ; region={}", avroStream.getName(), producerName, region);
-        if (!regionService.getSupportedRegions(avroStream.getTags().getHint()).contains(region))
-            throw new RegionNotFoundException(String.format("Region=%s not supported for hint=%s", region, avroStream.getTags().getHint()));
+
+        if (!avroStream.getVpcList().contains(region))
+            throw new RegionNotFoundException(String.format("Region=%s not supported for regions=%s", region, avroStream.getVpcList()));
 
         List<com.homeaway.digitalplatform.streamregistry.Producer> listProducers = avroStream.getProducers();
         if (listProducers == null) {

--- a/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/BaseResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/BaseResourceIT.java
@@ -99,6 +99,8 @@ public class BaseResourceIT {
 
     public static final String US_EAST_REGION = "us-east-1-vpc-defa0000";
 
+    public static final String US_EAST_REGION_2 = "us-east-2-vpc-defa0000";
+
     public static final String US_EAST_CLUSTER_NAME = "us-east-1_cluster001";
 
     public static final String US_EAST_CLUSTER_GENERAL = "us-east-1_clustergeneral";
@@ -327,6 +329,16 @@ public class BaseResourceIT {
             .put(KafkaProducerConfig.ZOOKEEPER_QUORUM, zookeeperQuorum)
             .build();
         infraManagerImplStub.upsertCluster(clusterKey,  new ClusterValue(clusterPropertiesMap));
+
+        // Inserting a second cluster with the same primary hint
+        ClusterKey clusterSameHintKey = new ClusterKey(US_EAST_REGION_2, ENV_TEST, AbstractService.PRIMARY_HINT, null);
+        final ImmutableMap<String, String> clusterSameHintPropertiesMap = new ImmutableMap.Builder<String, String>()
+                .put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+                .put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryURL)
+                .put(AbstractService.CLUSTER_NAME, US_EAST_CLUSTER_NAME)
+                .put(KafkaProducerConfig.ZOOKEEPER_QUORUM, zookeeperQuorum)
+                .build();
+        infraManagerImplStub.upsertCluster(clusterSameHintKey,  new ClusterValue(clusterSameHintPropertiesMap));
 
         // inserting another cluster with SOME_HINT
         ClusterKey motClusterKey = new ClusterKey(US_WEST_REGION, ENV_TEST, SOME_HINT, null);

--- a/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/ConsumerResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/ConsumerResourceIT.java
@@ -156,6 +156,21 @@ public class ConsumerResourceIT extends BaseResourceIT {
     }
 
     @Test
+    public void test_put_consumer_invalid_region_with_same_hint() throws InterruptedException {
+        String streamName = "junit-stream-put-invalid-region";
+        String consumerName = "C2";
+        // Stream exists in US_EAST_REGION
+        Stream stream = JsonModelBuilder.buildJsonStream(streamName);
+
+        streamResource.upsertStream(streamName, stream);
+        Thread.sleep(TEST_SLEEP_WAIT_MS); // wait for operation to propagate
+
+        Response response = consumerResource.upsertConsumer(streamName, consumerName, US_EAST_REGION_2);
+
+        Assert.assertEquals(Response.Status.PRECONDITION_FAILED.getStatusCode(), response.getStatus());
+    }
+
+    @Test
     public void test_put_consumer_with_no_stream() {
         String streamName = "junit-stream-consumer-with-no-stream";
         String consumerName = "C1";

--- a/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/ProducerResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/ProducerResourceIT.java
@@ -159,6 +159,23 @@ public class ProducerResourceIT extends BaseResourceIT {
     }
 
     @Test
+    public void test_put_producer_invalid_region_with_same_hint() throws InterruptedException {
+        String streamName = "junit-stream-invalid-region-1";
+        String producerName = "P2";
+        // Stream is created in US_EAST_REGION
+        Stream stream = JsonModelBuilder.buildJsonStream(streamName);
+
+        streamResource.upsertStream(streamName, stream);
+        Thread.sleep(TEST_SLEEP_WAIT_MS*2);
+
+        Assert.assertEquals(streamName, ((Stream) streamResource.getStream(streamName).getEntity()).getName());
+
+        Response response = producerResource.upsertProducer(streamName, producerName, US_EAST_REGION_2);
+
+        Assert.assertEquals(Response.Status.PRECONDITION_FAILED.getStatusCode(), response.getStatus());
+    }
+
+    @Test
     public void test_put_producer_with_no_stream() {
         String streamName = "junit-stream-put-producer-with-no-stream";
         String producerName = "P1";

--- a/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/RegionResourceIT.java
+++ b/core/src/test/java/com/homeaway/streamplatform/streamregistry/resource/RegionResourceIT.java
@@ -15,9 +15,7 @@
  */
 package com.homeaway.streamplatform.streamregistry.resource;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.*;
 
 import javax.ws.rs.core.Response;
 
@@ -40,7 +38,7 @@ public class RegionResourceIT extends BaseResourceIT {
 
         Collection<Hint> hints = (Collection<Hint>)response.getEntity();
 
-        Assert.assertEquals(new HashSet<>(Collections.singletonList(US_EAST_REGION)),
+        Assert.assertEquals(new HashSet<>(new ArrayList(Arrays.asList(US_EAST_REGION, US_EAST_REGION_2))),
                 hints.stream().filter((hint) -> hint.getHint().equalsIgnoreCase(AbstractService.PRIMARY_HINT)).findFirst().get().getVpcs());
         Assert.assertEquals(new HashSet<>(Collections.singletonList(US_EAST_REGION)),
                 hints.stream().filter((hint) -> hint.getHint().equalsIgnoreCase(BaseResourceIT.OTHER_HINT)).findFirst().get().getVpcs());


### PR DESCRIPTION
# stream-registry PR

Fix Stream consumer registers with an invalid region.  

Originally as long as the regions had the same hint, registering was allowed. This allowed consumers to be registered in regions where they should not have been.

### Changed
* Fix Consumers registering with invalid region
*_ConsumerServiceImpl now uses the stream's vpcList and replicatedVpcList to validate regions when registering
* Fix Producers registering with invalid region
*_ProducerServiceImpl now uses the stream's vpcList to validate regions when registering

# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 