### PR TITLE
updateStream contract change and upsert fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bugfix
 - Status field will return blank object when it is null for all the entities.
-- updateStream contract change(SchemaKeyInput not required in input) and upsertStream fixes for no schema in create
+- updateStream contract change(SchemaKeyInput not required in input) and upsertStream fixes for no schema during create
 
 ## [0.9.4] - 20200206
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Bugfix
 - Status field will return blank object when it is null for all the entities.
+- updateStream contract change(SchemaKeyInput not required in input) and upsertStream fixes for no schema in create
 
 ## [0.9.4] - 20200206
 ### Added

--- a/core/src/main/java/com/expediagroup/streamplatform/streamregistry/core/services/StreamService.java
+++ b/core/src/main/java/com/expediagroup/streamplatform/streamregistry/core/services/StreamService.java
@@ -63,6 +63,8 @@ public class StreamService {
     if (!existing.isPresent()) {
       throw new ValidationException("Can't update because it doesn't exist");
     }
+    //ignoring the provided schemaKey
+    stream.setSchemaKey(existing.get().getSchemaKey());
     streamValidator.validateForUpdate(stream, existing.get());
     stream.setSpecification(handlerService.handleUpdate(stream, existing.get()));
     return streamServiceEventEmitter.emitEventOnProcessedEntity(EventType.UPDATE, streamRepository.save(stream));

--- a/core/src/main/java/com/expediagroup/streamplatform/streamregistry/core/services/StreamService.java
+++ b/core/src/main/java/com/expediagroup/streamplatform/streamregistry/core/services/StreamService.java
@@ -63,7 +63,10 @@ public class StreamService {
     if (!existing.isPresent()) {
       throw new ValidationException("Can't update because it doesn't exist");
     }
-    //ignoring the provided schemaKey
+    if(stream.getSchemaKey() != null && !stream.getSchemaKey().equals(existing.get().getSchemaKey())) {
+      //there is a schema change
+      throw new ValidationException("Can't update because schema change is not allowed");
+    }
     stream.setSchemaKey(existing.get().getSchemaKey());
     streamValidator.validateForUpdate(stream, existing.get());
     stream.setSpecification(handlerService.handleUpdate(stream, existing.get()));

--- a/core/src/main/java/com/expediagroup/streamplatform/streamregistry/core/validators/StreamValidator.java
+++ b/core/src/main/java/com/expediagroup/streamplatform/streamregistry/core/validators/StreamValidator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia, Inc.
+ * Copyright (C) 2018-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,10 @@ public class StreamValidator implements Validator<Stream> {
 
   @Override
   public void validateForCreate(Stream stream) throws ValidationException {
+    if(stream.getSchemaKey() == null) {
+      //this can happen when doing create using upsert
+      throw new ValidationException("Can't create because Schema is required");
+    }
     validateForCreateAndUpdate(stream);
     specificationValidator.validateForCreate(stream.getSpecification());
   }

--- a/graphql-api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/StreamMutation.java
+++ b/graphql-api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/StreamMutation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia, Inc.
+ * Copyright (C) 2018-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import com.expediagroup.streamplatform.streamregistry.model.Stream;
 public interface StreamMutation extends GraphQLApiType {
   Stream insert(StreamKeyInput key, SpecificationInput specification, SchemaKeyInput schema);
 
-  Stream update(StreamKeyInput key, SpecificationInput specification, SchemaKeyInput schema);
+  Stream update(StreamKeyInput key, SpecificationInput specification);
 
   Stream upsert(StreamKeyInput key, SpecificationInput specification, SchemaKeyInput schema);
 

--- a/graphql-api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/StreamMutationImpl.java
+++ b/graphql-api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/StreamMutationImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia, Inc.
+ * Copyright (C) 2018-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package com.expediagroup.streamplatform.streamregistry.graphql.mutation.impl;
 
 import static com.expediagroup.streamplatform.streamregistry.graphql.StateHelper.maintainState;
+
+import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,17 +38,17 @@ public class StreamMutationImpl implements StreamMutation {
 
   @Override
   public Stream insert(StreamKeyInput key, SpecificationInput specification, SchemaKeyInput schema) {
-    return streamService.create(asStream(key, specification, schema)).get();
+    return streamService.create(asStream(key, specification, Optional.of(schema))).get();
   }
 
   @Override
-  public Stream update(StreamKeyInput key, SpecificationInput specification, SchemaKeyInput schema) {
-    return streamService.update(asStream(key, specification, schema)).get();
+  public Stream update(StreamKeyInput key, SpecificationInput specification) {
+    return streamService.update(asStream(key, specification, Optional.empty())).get();
   }
 
   @Override
   public Stream upsert(StreamKeyInput key, SpecificationInput specification, SchemaKeyInput schema) {
-    return streamService.upsert(asStream(key, specification, schema)).get();
+    return streamService.upsert(asStream(key, specification, Optional.ofNullable(schema))).get();
   }
 
   @Override
@@ -61,11 +63,13 @@ public class StreamMutationImpl implements StreamMutation {
     return streamService.update(stream).get();
   }
 
-  private Stream asStream(StreamKeyInput key, SpecificationInput specification, SchemaKeyInput schema) {
+  private Stream asStream(StreamKeyInput key, SpecificationInput specification, Optional<SchemaKeyInput> schema) {
     Stream stream = new Stream();
     stream.setKey(key.asStreamKey());
     stream.setSpecification(specification.asSpecification());
-    stream.setSchemaKey(schema.asSchemaKey());
+    if(schema.isPresent()) {
+      stream.setSchemaKey(schema.get().asSchemaKey());
+    }
     maintainState(stream, streamService.read(stream.getKey()));
     return stream;
   }

--- a/graphql-api/src/main/resources/stream-registry.graphql
+++ b/graphql-api/src/main/resources/stream-registry.graphql
@@ -385,7 +385,7 @@ type SchemaMutation{
 
 type StreamMutation{
     insert(key: StreamKeyInput!, specification: SpecificationInput!, schema: SchemaKeyInput!): Stream!
-    update(key: StreamKeyInput!, specification: SpecificationInput!, schema: SchemaKeyInput!): Stream!
+    update(key: StreamKeyInput!, specification: SpecificationInput!): Stream!
     upsert(key: StreamKeyInput!, specification: SpecificationInput!, schema: SchemaKeyInput): Stream!
     delete(key: StreamKeyInput!): Boolean!
     updateStatus(key: StreamKeyInput!, status: StatusInput!): Stream!

--- a/graphql-client/src/main/graphql/client.graphql
+++ b/graphql-client/src/main/graphql/client.graphql
@@ -729,10 +729,9 @@ mutation InsertStream(
 mutation UpdateStream(
     $key: StreamKeyInput!
     $specification: SpecificationInput!
-    $schema: SchemaKeyInput!
 ) {
     stream{
-        update(key: $key,specification: $specification, schema: $schema){
+        update(key: $key,specification: $specification){
             __typename
             ...StreamPart
         }

--- a/graphql-client/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/client/StreamRegistryClient.java
+++ b/graphql-client/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/client/StreamRegistryClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia, Inc.
+ * Copyright (C) 2018-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/StreamTestStage.java
+++ b/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/StreamTestStage.java
@@ -54,6 +54,15 @@ public class StreamTestStage extends AbstractTestStage {
 
   @Override
   public void upsert() {
+    //insert scenario without schema
+    try {
+      client.getOptionalData(factory.upsertStreamMutationInsertWithoutSchemaBuilder().build()).get();
+    }
+    catch(RuntimeException ex) {
+        assertEquals("Can't create because Schema is required", ex.getMessage());
+    }
+
+    //update scenario
     Object data = client.getOptionalData(factory.upsertStreamMutationBuilder().build()).get();
 
     UpsertStreamMutation.Upsert upsert = ((UpsertStreamMutation.Data) data).getStream().getUpsert();

--- a/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/StreamTestStage.java
+++ b/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/StreamTestStage.java
@@ -62,6 +62,14 @@ public class StreamTestStage extends AbstractTestStage {
         assertEquals("Can't create because Schema is required", ex.getMessage());
     }
 
+    //upsert scenario with a different schema
+    try {
+      client.getOptionalData(factory.upsertStreamMutationUpsertWithDifferentSchemaKeySchemaBuilder().build()).get();
+    }
+    catch(RuntimeException ex) {
+      assertEquals("Can't update because schema change is not allowed", ex.getMessage());
+    }
+
     //update scenario
     Object data = client.getOptionalData(factory.upsertStreamMutationBuilder().build()).get();
 

--- a/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/helpers/ITestClient.java
+++ b/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/helpers/ITestClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia, Inc.
+ * Copyright (C) 2018-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/helpers/ITestDataFactory.java
+++ b/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/helpers/ITestDataFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia, Inc.
+ * Copyright (C) 2018-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,6 +79,7 @@ public class ITestDataFactory {
   public String domainName;
   public String consumerName;
   public String streamName;
+  public String nonExistingStreamName;
   public String key;
   public String value;
   public String description;
@@ -90,6 +91,7 @@ public class ITestDataFactory {
     domainName = "domain_name_" + suffix;
     consumerName = "consumer_name_" + suffix;
     streamName = "stream_name_" + suffix;
+    nonExistingStreamName = "non_existing_stream_name_" + suffix;
 
     infrastructureName = "infrastructure_name_" + suffix;
     producerName = "producer_name_" + suffix;
@@ -266,7 +268,6 @@ public class ITestDataFactory {
   public UpdateStreamMutation.Builder updateStreamMutationBuilder() {
     return UpdateStreamMutation.builder()
         .specification(specificationInputBuilder(DEFAULT).build())
-        .schema(schemaKeyInputBuilder().build())
         .key(streamKeyInputBuilder().build());
   }
 
@@ -275,6 +276,19 @@ public class ITestDataFactory {
         .specification(specificationInputBuilder(DEFAULT).build())
         .schema(schemaKeyInputBuilder().build())
         .key(streamKeyInputBuilder().build());
+  }
+
+  public UpsertStreamMutation.Builder upsertStreamMutationInsertWithoutSchemaBuilder() {
+    return UpsertStreamMutation.builder()
+        .specification(specificationInputBuilder(DEFAULT).build())
+        .key(streamKeyUnknownNameInputBuilder().build());
+  }
+
+  public StreamKeyInput.Builder streamKeyUnknownNameInputBuilder() {
+    return StreamKeyInput.builder()
+        .domain(domainName)
+        .name(nonExistingStreamName)
+        .version(1);
   }
 
   public StreamKeyInput.Builder streamKeyInputBuilder() {

--- a/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/helpers/ITestDataFactory.java
+++ b/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/helpers/ITestDataFactory.java
@@ -80,6 +80,7 @@ public class ITestDataFactory {
   public String consumerName;
   public String streamName;
   public String nonExistingStreamName;
+  public String alternativeStreamName;
   public String key;
   public String value;
   public String description;
@@ -92,7 +93,7 @@ public class ITestDataFactory {
     consumerName = "consumer_name_" + suffix;
     streamName = "stream_name_" + suffix;
     nonExistingStreamName = "non_existing_stream_name_" + suffix;
-
+    alternativeStreamName = "alternative_stream_name_" + suffix;
     infrastructureName = "infrastructure_name_" + suffix;
     producerName = "producer_name_" + suffix;
 
@@ -284,6 +285,13 @@ public class ITestDataFactory {
         .key(streamKeyNonExistingStreamInputBuilder().build());
   }
 
+  public UpsertStreamMutation.Builder upsertStreamMutationUpsertWithDifferentSchemaKeySchemaBuilder() {
+    return UpsertStreamMutation.builder()
+        .specification(specificationInputBuilder(DEFAULT).build())
+        .schema(schemaKeyChangedSchemaInputBuilder().build())
+        .key(streamKeyInputBuilder().build());
+  }
+
   public StreamKeyInput.Builder streamKeyNonExistingStreamInputBuilder() {
     return StreamKeyInput.builder()
         .domain(domainName)
@@ -320,6 +328,12 @@ public class ITestDataFactory {
     return SchemaKeyInput.builder()
         .domain(domainName)
         .name(streamName);
+  }
+
+  public SchemaKeyInput.Builder schemaKeyChangedSchemaInputBuilder() {
+    return SchemaKeyInput.builder()
+        .domain(domainName)
+        .name(alternativeStreamName);
   }
 
   public InsertStreamBindingMutation.Builder insertStreamBindingMutationBuilder() {

--- a/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/helpers/ITestDataFactory.java
+++ b/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/helpers/ITestDataFactory.java
@@ -281,10 +281,10 @@ public class ITestDataFactory {
   public UpsertStreamMutation.Builder upsertStreamMutationInsertWithoutSchemaBuilder() {
     return UpsertStreamMutation.builder()
         .specification(specificationInputBuilder(DEFAULT).build())
-        .key(streamKeyUnknownNameInputBuilder().build());
+        .key(streamKeyNonExistingStreamInputBuilder().build());
   }
 
-  public StreamKeyInput.Builder streamKeyUnknownNameInputBuilder() {
+  public StreamKeyInput.Builder streamKeyNonExistingStreamInputBuilder() {
     return StreamKeyInput.builder()
         .domain(domainName)
         .name(nonExistingStreamName)

--- a/model/src/main/java/com/expediagroup/streamplatform/streamregistry/model/Stream.java
+++ b/model/src/main/java/com/expediagroup/streamplatform/streamregistry/model/Stream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia, Inc.
+ * Copyright (C) 2018-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.expediagroup.streamplatform.streamregistry.model;
 
+import javax.persistence.Column;
 import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 
@@ -30,6 +31,7 @@ public class Stream implements ManagedType {
   @EmbeddedId
   private StreamKey key;
 
+  @Column(updatable = false)
   private SchemaKey schemaKey;
   private Specification specification;
   private Status status;

--- a/model/src/main/java/com/expediagroup/streamplatform/streamregistry/model/keys/SchemaKey.java
+++ b/model/src/main/java/com/expediagroup/streamplatform/streamregistry/model/keys/SchemaKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2019 Expedia, Inc.
+ * Copyright (C) 2018-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,12 +22,14 @@ import javax.persistence.Embeddable;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Embeddable
+@EqualsAndHashCode
 public class SchemaKey implements Serializable {
 
   @Column(name = "SKdomain", length = 100)


### PR DESCRIPTION
# stream-registry PR

updateStream contract change and upsertStream fixes

### Changed
* updateStream no longer allows SchemaKeyInput as input 
* upsertStream will return a proper validation error if schema is not provided during create

# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
