### PR TITLE
STREAMP-2307: Access control setup to handle who can perform mutations on GraphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Access control setup to handle who can perform mutations on GraphQL.
+
 ## [0.14.2] - 2020-09-29
 ### Added
 - Added CLI command to discover and delete all child entities of a stream.

--- a/cli/src/test/java/com/expediagroup/streamplatform/streamregistry/cli/command/delete/DeleteTest.java
+++ b/cli/src/test/java/com/expediagroup/streamplatform/streamregistry/cli/command/delete/DeleteTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 20VERSION8-2020 Expedia, Inc.
+ * Copyright (C) 2018-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,9 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import picocli.CommandLine;
+import picocli.CommandLine.ParseResult;
+
 import com.expediagroup.streamplatform.streamregistry.cli.command.delete.EntityClient.StreamKeyWithSchemaKey;
 import com.expediagroup.streamplatform.streamregistry.state.model.Entity.ConsumerBindingKey;
 import com.expediagroup.streamplatform.streamregistry.state.model.Entity.ConsumerKey;
@@ -40,9 +43,6 @@ import com.expediagroup.streamplatform.streamregistry.state.model.Entity.SchemaK
 import com.expediagroup.streamplatform.streamregistry.state.model.Entity.StreamBindingKey;
 import com.expediagroup.streamplatform.streamregistry.state.model.Entity.StreamKey;
 import com.expediagroup.streamplatform.streamregistry.state.model.Entity.ZoneKey;
-
-import picocli.CommandLine;
-import picocli.CommandLine.ParseResult;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class DeleteTest {

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/Mutation.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/Mutation.java
@@ -18,6 +18,7 @@ package com.expediagroup.streamplatform.streamregistry.graphql.mutation;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
 
 import graphql.kickstart.tools.GraphQLMutationResolver;
@@ -25,7 +26,9 @@ import graphql.kickstart.tools.GraphQLMutationResolver;
 @Component
 @RequiredArgsConstructor
 @Getter
+@PreAuthorize("hasAuthority('stream_registry_writes')")
 public class Mutation implements GraphQLMutationResolver {
+
   private final DomainMutation domain;
   private final SchemaMutation schema;
   private final StreamMutation stream;
@@ -36,4 +39,5 @@ public class Mutation implements GraphQLMutationResolver {
   private final StreamBindingMutation streamBinding;
   private final ProducerBindingMutation producerBinding;
   private final ConsumerBindingMutation consumerBinding;
+
 }

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/Mutation.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/Mutation.java
@@ -26,7 +26,7 @@ import graphql.kickstart.tools.GraphQLMutationResolver;
 @Component
 @RequiredArgsConstructor
 @Getter
-@PreAuthorize("hasAuthority('stream_registry_writes')")
+@PreAuthorize("@security.authorize()")
 public class Mutation implements GraphQLMutationResolver {
 
   private final DomainMutation domain;

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/security/AuthorizationContext.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/security/AuthorizationContext.java
@@ -15,11 +15,7 @@
  */
 package com.expediagroup.streamplatform.streamregistry.graphql.security;
 
-import java.util.function.Predicate;
+public interface AuthorizationContext<T> {
 
-import org.springframework.security.core.context.SecurityContext;
-
-public interface AuthorizationProvider {
-
-  Predicate<SecurityContext> provide();
+  boolean isAuthorized(T type);
 }

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/security/AuthorizationContextProvider.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/security/AuthorizationContextProvider.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2018-2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.streamplatform.streamregistry.graphql.security;
+
+public interface AuthorizationContextProvider<T> {
+
+  AuthorizationContext<T> provide();
+}

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/security/AuthorizationProvider.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/security/AuthorizationProvider.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2018-2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.streamplatform.streamregistry.graphql.security;
+
+import java.util.function.Predicate;
+
+import org.springframework.security.core.context.SecurityContext;
+
+public interface AuthorizationProvider {
+
+  Predicate<SecurityContext> provide();
+}

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/security/SecurityAuthorizer.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/security/SecurityAuthorizer.java
@@ -43,18 +43,13 @@ public class SecurityAuthorizer {
         .getBeanProvider(AuthorizationProvider.class);
 
     AuthorizationProvider authorizationProvider = authorizationProviderObjectProvider
-        .getIfAvailable(() -> () -> securityContext -> true);
+        .getIfAvailable(() -> () -> securityContext -> false);
 
     Predicate<SecurityContext> provide = authorizationProvider.provide();
     SecurityContext securityContext = SecurityContextHolder.getContext();
     boolean isAccessGranted = provide.test(securityContext);
     log.info("Authorization isAccessGranted: {}", isAccessGranted);
     return isAccessGranted;
-  }
-
-  public interface AuthorizationProvider {
-
-    Predicate<SecurityContext> provide();
   }
 
   @Getter

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/security/SecurityAuthorizer.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/security/SecurityAuthorizer.java
@@ -15,7 +15,6 @@
  */
 package com.expediagroup.streamplatform.streamregistry.graphql.security;
 
-import java.util.function.Predicate;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -38,16 +37,17 @@ public class SecurityAuthorizer {
 
   private final BeanFactory beanFactory;
 
+  @SuppressWarnings("unchecked")
   public boolean authorize() {
-    ObjectProvider<AuthorizationProvider> authorizationProviderObjectProvider = beanFactory
-        .getBeanProvider(AuthorizationProvider.class);
+    ObjectProvider<AuthorizationContextProvider> authorizationProviderObjectProvider = beanFactory
+        .getBeanProvider(AuthorizationContextProvider.class);
 
-    AuthorizationProvider authorizationProvider = authorizationProviderObjectProvider
+    AuthorizationContextProvider<SecurityContext> authorizationContextProvider = authorizationProviderObjectProvider
         .getIfAvailable(() -> () -> securityContext -> false);
 
-    Predicate<SecurityContext> provide = authorizationProvider.provide();
+    AuthorizationContext<SecurityContext> provide = authorizationContextProvider.provide();
     SecurityContext securityContext = SecurityContextHolder.getContext();
-    boolean isAccessGranted = provide.test(securityContext);
+    boolean isAccessGranted = provide.isAuthorized(securityContext);
     log.info("Authorization isAccessGranted: {}", isAccessGranted);
     return isAccessGranted;
   }

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/security/SecurityAuthorizer.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/security/SecurityAuthorizer.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2018-2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.streamplatform.streamregistry.graphql.security;
+
+import java.util.function.Predicate;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.security.access.expression.SecurityExpressionRoot;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component("security")
+@RequiredArgsConstructor
+public class SecurityAuthorizer {
+
+  private final BeanFactory beanFactory;
+
+  public boolean authorize() {
+    ObjectProvider<AuthorizationProvider> authorizationProviderObjectProvider = beanFactory
+        .getBeanProvider(AuthorizationProvider.class);
+
+    AuthorizationProvider authorizationProvider = authorizationProviderObjectProvider
+        .getIfAvailable(() -> () -> securityContext -> true);
+
+    Predicate<SecurityContext> provide = authorizationProvider.provide();
+    SecurityContext securityContext = SecurityContextHolder.getContext();
+    boolean isAccessGranted = provide.test(securityContext);
+    log.info("Authorization isAccessGranted: {}", isAccessGranted);
+    return isAccessGranted;
+  }
+
+  public interface AuthorizationProvider {
+
+    Predicate<SecurityContext> provide();
+  }
+
+  @Getter
+  @Setter
+  public static class CustomMethodSecurityExpressionRoot extends SecurityExpressionRoot implements
+      MethodSecurityExpressionOperations {
+
+    private Object filterObject;
+    private Object returnObject;
+    private Object target;
+
+    public CustomMethodSecurityExpressionRoot(
+        Authentication authentication) {
+      super(authentication);
+    }
+
+    public void setThis(Object target) {
+      this.target = target;
+    }
+
+    @Override
+    public Object getThis() {
+      return target;
+    }
+  }
+}

--- a/state/graphql-sender/src/main/java/com/expediagroup/streamplatform/streamregistry/state/graphql/DefaultApolloClientFactory.java
+++ b/state/graphql-sender/src/main/java/com/expediagroup/streamplatform/streamregistry/state/graphql/DefaultApolloClientFactory.java
@@ -17,15 +17,16 @@ package com.expediagroup.streamplatform.streamregistry.state.graphql;
 
 import static com.expediagroup.streamplatform.streamregistry.state.graphql.type.CustomType.OBJECTNODE;
 import static okhttp3.Credentials.basic;
+
 import java.util.function.Consumer;
 
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import okhttp3.OkHttpClient;
+import okhttp3.OkHttpClient.Builder;
 
 import com.apollographql.apollo.ApolloClient;
-import okhttp3.OkHttpClient.Builder;
 
 @AllArgsConstructor
 public class DefaultApolloClientFactory implements ApolloClientFactory {

--- a/state/graphql-sender/src/test/java/com/expediagroup/streamplatform/streamregistry/state/graphql/DefaultApolloClientFactoryTest.java
+++ b/state/graphql-sender/src/test/java/com/expediagroup/streamplatform/streamregistry/state/graphql/DefaultApolloClientFactoryTest.java
@@ -25,8 +25,10 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.apollographql.apollo.ApolloClient;
 import okhttp3.OkHttpClient;
+
+import com.apollographql.apollo.ApolloClient;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;


### PR DESCRIPTION
# stream-registry PR

STREAMP-2307: Access control setup to handle who can perform mutations on GraphQL

### Added
* `AuthorizationContextProvider` interface added
* `SecurityAuthorizer` component added to abstract custom authorization rules.

### Changed
* GraphQL `Mutation` class annotated with custom security authorizer


# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
