### PR TITLE
Expose apollo response on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+### Changed
+- `ApolloExecutor` returns a `ApolloResponseException` with access to the underlying `Response` on errors.
+
 ## [0.15.1] - 2020-11-16
 ### Changed
 - cli: On cascading stream delete, don't delete schemas that are being used by other streams.

--- a/state/graphql-sender/src/main/java/com/expediagroup/streamplatform/streamregistry/state/graphql/ApolloExecutor.java
+++ b/state/graphql-sender/src/main/java/com/expediagroup/streamplatform/streamregistry/state/graphql/ApolloExecutor.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloClient;
+import com.apollographql.apollo.api.Error;
 import com.apollographql.apollo.api.Mutation;
 import com.apollographql.apollo.api.Operation.Data;
 import com.apollographql.apollo.api.Operation.Variables;
@@ -59,8 +60,13 @@ public class ApolloExecutor {
     @Override
     public void onResponse(@NotNull Response<T> response) {
       if (response.hasErrors()) {
-        List<com.apollographql.apollo.api.Error> errors = response.getErrors();
-        future.completeExceptionally(new IllegalStateException("Unexpected response: " + errors.stream().map(e -> e.getMessage()).collect(joining(", "))));
+        List<Error> errors = response.getErrors();
+        future.completeExceptionally(
+          new ApolloResponseException(
+            "Unexpected response: " + errors.stream().map(e -> e.getMessage()).collect(joining(", ")),
+            response
+          )
+        );
       } else {
         future.complete(response);
       }

--- a/state/graphql-sender/src/main/java/com/expediagroup/streamplatform/streamregistry/state/graphql/ApolloResponseException.java
+++ b/state/graphql-sender/src/main/java/com/expediagroup/streamplatform/streamregistry/state/graphql/ApolloResponseException.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2018-2020 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.streamplatform.streamregistry.state.graphql;
+
+import lombok.Getter;
+
+import com.apollographql.apollo.api.Response;
+
+@Getter
+public class ApolloResponseException extends IllegalStateException {
+
+  private final Response<?> response;
+
+  public ApolloResponseException(String message, Response<?> response) {
+    super(message);
+    this.response = response;
+  }
+}

--- a/state/graphql-sender/src/test/java/com/expediagroup/streamplatform/streamregistry/state/graphql/ApolloExecutorTest.java
+++ b/state/graphql-sender/src/test/java/com/expediagroup/streamplatform/streamregistry/state/graphql/ApolloExecutorTest.java
@@ -16,7 +16,9 @@
 package com.expediagroup.streamplatform.streamregistry.state.graphql;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -78,6 +80,13 @@ public class ApolloExecutorTest {
     when(response.hasErrors()).thenReturn(true);
     callback.onResponse(response);
     assertThat(result.isCompletedExceptionally(), is(true));
+    try {
+      result.get();
+      fail("Expected exception");
+    } catch (Exception ex) {
+      assertThat(ex.getCause(), instanceOf(ApolloResponseException.class));
+      assertThat(((ApolloResponseException)ex.getCause()).getResponse(), is(response));
+    }
   }
 
   @Test


### PR DESCRIPTION
# stream-registry PR

Introduces a new exception that allows access to the `Response` when the `ApolloExecutor` encounters errors.  

### Changed
* `ApolloExecutor` returns a `ApolloResponseException` with access to the underlying `Response` on errors. 

# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
