### PR TITLE
Add state to kafka event receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+### Added 
+- Added `State` property to `KafkaEventReceiver`
+
+## [0.19.1] - 2021-04-26
+### Changed
+- Made the SecurityInput list nullable
+
+## [0.19.0] - 2021-04-21 
 ### Added
-- Implemented entity delete functionality.
 - Added `security` to Specification models.
 
 ### Changed
 - Added `security` to AvroSpecification and AvroStreamSpecification schemas, defaulting to empty map.
+
+## [0.18.0] - 2021-03-24
+### Added
+- Implemented entity delete functionality.
 
 ## [0.17.0] - 2021-01-29
 ### Changed

--- a/state/kafka-receiver/pom.xml
+++ b/state/kafka-receiver/pom.xml
@@ -39,6 +39,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/state/kafka-receiver/src/main/java/com/expediagroup/streamplatform/streamregistry/state/kafka/KafkaEventReceiver.java
+++ b/state/kafka-receiver/src/main/java/com/expediagroup/streamplatform/streamregistry/state/kafka/KafkaEventReceiver.java
@@ -16,9 +16,10 @@
 package com.expediagroup.streamplatform.streamregistry.state.kafka;
 
 import static com.expediagroup.streamplatform.streamregistry.state.internal.EventCorrelator.CORRELATION_ID;
-import static com.expediagroup.streamplatform.streamregistry.state.kafka.KafkaEventReceiver.State.CLOSED;
+import static com.expediagroup.streamplatform.streamregistry.state.kafka.KafkaEventReceiver.State.NOT_RUNNING;
 import static com.expediagroup.streamplatform.streamregistry.state.kafka.KafkaEventReceiver.State.ERROR;
 import static com.expediagroup.streamplatform.streamregistry.state.kafka.KafkaEventReceiver.State.CREATED;
+import static com.expediagroup.streamplatform.streamregistry.state.kafka.KafkaEventReceiver.State.PENDING_SHUTDOWN;
 import static com.expediagroup.streamplatform.streamregistry.state.kafka.KafkaEventReceiver.State.RUNNING;
 import static com.expediagroup.streamplatform.streamregistry.state.model.event.Event.LOAD_COMPLETE;
 import static io.confluent.kafka.serializers.KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG;
@@ -163,9 +164,10 @@ public class KafkaEventReceiver implements EventReceiver {
 
   @Override
   public void close() {
-    state.set(CLOSED);
+    state.set(PENDING_SHUTDOWN);
     executorService.shutdown();
     consumer.close();
+    state.set(NOT_RUNNING);
   }
 
   public State getState() {
@@ -198,6 +200,7 @@ public class KafkaEventReceiver implements EventReceiver {
     CREATED,
     RUNNING,
     ERROR,
-    CLOSED
+    PENDING_SHUTDOWN,
+    NOT_RUNNING
   }
 }

--- a/state/kafka-receiver/src/test/java/com/expediagroup/streamplatform/streamregistry/state/kafka/KafkaEventReceiverTest.java
+++ b/state/kafka-receiver/src/test/java/com/expediagroup/streamplatform/streamregistry/state/kafka/KafkaEventReceiverTest.java
@@ -16,7 +16,7 @@
 package com.expediagroup.streamplatform.streamregistry.state.kafka;
 
 import static com.expediagroup.streamplatform.streamregistry.state.internal.EventCorrelator.CORRELATION_ID;
-import static com.expediagroup.streamplatform.streamregistry.state.kafka.KafkaEventReceiver.State.CLOSED;
+import static com.expediagroup.streamplatform.streamregistry.state.kafka.KafkaEventReceiver.State.NOT_RUNNING;
 import static com.expediagroup.streamplatform.streamregistry.state.kafka.KafkaEventReceiver.State.ERROR;
 import static com.expediagroup.streamplatform.streamregistry.state.kafka.KafkaEventReceiver.State.RUNNING;
 import static com.expediagroup.streamplatform.streamregistry.state.model.event.Event.LOAD_COMPLETE;
@@ -117,7 +117,7 @@ public class KafkaEventReceiverTest {
     assertThat(underTest.getState(), is(RUNNING));
     latch.await(1, SECONDS);
     underTest.close();
-    assertThat(underTest.getState(), is(CLOSED));
+    assertThat(underTest.getState(), is(NOT_RUNNING));
 
     val inOrder = Mockito.inOrder(consumer, listener, correlator);
     inOrder.verify(consumer).assign(topicPartitions);
@@ -149,7 +149,7 @@ public class KafkaEventReceiverTest {
     latch.await(1, SECONDS);
     assertThat(underTest.getState(), is(RUNNING));
     underTest.close();
-    assertThat(underTest.getState(), is(CLOSED));
+    assertThat(underTest.getState(), is(NOT_RUNNING));
 
     val inOrder = Mockito.inOrder(consumer, listener, correlator);
     inOrder.verify(consumer).assign(topicPartitions);
@@ -172,7 +172,7 @@ public class KafkaEventReceiverTest {
     await.untilAsserted(() -> assertThat(underTest.getState(), is(ERROR)));
 
     underTest.close();
-    assertThat(underTest.getState(), is(CLOSED));
+    assertThat(underTest.getState(), is(NOT_RUNNING));
   }
 
   @Test
@@ -212,7 +212,7 @@ public class KafkaEventReceiverTest {
     await.untilAsserted(() -> assertThat(underTest.getState(), is(ERROR)));
     verify(consumer, times(11)).poll(any());
     underTest.close();
-    assertThat(underTest.getState(), is(CLOSED));
+    assertThat(underTest.getState(), is(NOT_RUNNING));
   }
 
   @Test(expected = IllegalStateException.class)

--- a/state/kafka-receiver/src/test/java/com/expediagroup/streamplatform/streamregistry/state/kafka/KafkaEventReceiverTest.java
+++ b/state/kafka-receiver/src/test/java/com/expediagroup/streamplatform/streamregistry/state/kafka/KafkaEventReceiverTest.java
@@ -160,12 +160,13 @@ public class KafkaEventReceiverTest {
   }
 
   @Test
-  public void errorWhenWrongPartitionCount() {
+  public void errorWhenMoreThanOnePartition() {
     when(config.getTopic()).thenReturn(topic);
-    val topicPartitionsList = new ArrayList<PartitionInfo>();
-    topicPartitionsList.add(partitionInfo);
-    topicPartitionsList.add(partitionInfo);
-    when(consumer.partitionsFor(topic)).thenReturn(topicPartitionsList);
+    val multiplePartitions = new ArrayList<PartitionInfo>() {{
+      add(partitionInfo);
+      add(partitionInfo);
+    }};
+    when(consumer.partitionsFor(topic)).thenReturn(multiplePartitions);
 
     underTest.receive(listener);
     verify(consumer, timeout(100)).partitionsFor(topic);


### PR DESCRIPTION
# stream-registry PR

Adding a `State` to the `KafkaEventReceiver`. Allows users to check the polling thread, giving the option of running application health checks based on `KafkaEventReceiver`. State names heavily influenced from `KafkaStreams`.

### Added

- `getState()` method on `KafkaEventReceiver`

# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
