### PR TITLE
Expose multi status model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,28 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+### Changed
+- Exposed multi-status repo model out to GQL endpoint, keeping backwards compatibility.
+  It should now be possible to provide multiple status for a single entity.
+
+## [0.19.1] - 2021-04-26
+### Changed
+- SecurityInput list in SpecificationInput nullable (#284)
+
+## [0.19.0] - 2021-02-21
 ### Added
-- Implemented entity delete functionality.
 - Added `security` to Specification models.
 
 ### Changed
 - Added `security` to AvroSpecification and AvroStreamSpecification schemas, defaulting to empty map.
+
+## [0.18.0] - 2021-03-24
+### Added
+- add graphql delete functionality (#273)
+
+## [0.17.1] - 2021-03-01
+### Changed
+-  resolving kotlin-stdlib versions in graphql-sender (#275)
 
 ## [0.17.0] - 2021-01-29
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [unreleased]
 ### Changed
 - Exposed multi-status repo model out to GQL endpoint, keeping backwards compatibility.
-  It should now be possible to provide multiple status for a single entity.
+- Status now also includes created/updated timestamp.
 
 ## [0.19.1] - 2021-04-26
 ### Changed

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/model/inputs/StatusEntryInput.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/model/inputs/StatusEntryInput.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2020 Expedia, Inc.
+ * Copyright (C) 2018-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.expediagroup.streamplatform.streamregistry.graphql.resolvers;
+package com.expediagroup.streamplatform.streamregistry.graphql.model.inputs;
+
+import lombok.Builder;
+import lombok.Value;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import org.springframework.stereotype.Component;
+import com.expediagroup.streamplatform.streamregistry.model.StatusEntry;
 
-import com.expediagroup.streamplatform.streamregistry.model.Status;
-
-@Component
-public class StatusResolver implements Resolvers.StatusResolver {
-  public ObjectNode getAgentStatus(Status status) {
-    return status.getObjectNode();
-  }
+@Value
+@Builder
+public class StatusEntryInput {
+  String name;
+  ObjectNode value;
+  StatusEntry.State state;
 }

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/model/inputs/StatusInput.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/model/inputs/StatusInput.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2020 Expedia, Inc.
+ * Copyright (C) 2018-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,49 @@
  */
 package com.expediagroup.streamplatform.streamregistry.graphql.model.inputs;
 
+import static com.expediagroup.streamplatform.streamregistry.model.StatusEntry.State.UNDEFINED;
+import static java.util.Collections.unmodifiableMap;
+
+import java.time.Clock;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import lombok.Builder;
 import lombok.Value;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import com.expediagroup.streamplatform.streamregistry.model.Status;
+import com.expediagroup.streamplatform.streamregistry.model.StatusEntry;
 
 @Value
 @Builder
 public class StatusInput {
+  @Deprecated
   ObjectNode agentStatus;
+  List<StatusEntryInput> entries;
 
   public Status asStatus() {
-    return new Status(agentStatus);
+    Map<String, StatusEntry> m = new HashMap<>();
+    if (agentStatus != null) {
+      // Backwards compatibility
+      m.put("agentStatus",
+        new StatusEntry(
+          "agentStatus",
+          agentStatus,
+          Clock.systemUTC().instant(),
+          UNDEFINED
+        )
+      );
+    }
+    if (entries != null) {
+      for (StatusEntryInput i : entries) {
+        String k = i.getName();
+        StatusEntry e = new StatusEntry(i.getName(), i.getValue(), Clock.systemUTC().instant(), i.getState());
+        m.put(k, e);
+      }
+    }
+    return new Status(unmodifiableMap(m));
   }
 }

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/model/inputs/StatusInput.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/model/inputs/StatusInput.java
@@ -18,7 +18,6 @@ package com.expediagroup.streamplatform.streamregistry.graphql.model.inputs;
 import static com.expediagroup.streamplatform.streamregistry.model.StatusEntry.State.UNDEFINED;
 import static java.util.Collections.unmodifiableMap;
 
-import java.time.Clock;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +45,6 @@ public class StatusInput {
         new StatusEntry(
           "agentStatus",
           agentStatus,
-          Clock.systemUTC().instant(),
           UNDEFINED
         )
       );
@@ -54,7 +52,7 @@ public class StatusInput {
     if (entries != null) {
       for (StatusEntryInput i : entries) {
         String k = i.getName();
-        StatusEntry e = new StatusEntry(i.getName(), i.getValue(), Clock.systemUTC().instant(), i.getState());
+        StatusEntry e = new StatusEntry(i.getName(), i.getValue(), i.getState());
         m.put(k, e);
       }
     }

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/resolvers/Resolvers.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/resolvers/Resolvers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2020 Expedia, Inc.
+ * Copyright (C) 2018-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@ package com.expediagroup.streamplatform.streamregistry.graphql.resolvers;
 
 import java.util.List;
 import java.util.Optional;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import com.expediagroup.streamplatform.streamregistry.graphql.GraphQLApiType;
 import com.expediagroup.streamplatform.streamregistry.model.Consumer;
@@ -88,10 +86,6 @@ interface Resolvers {
     Producer producer(ProducerBinding producerBinding);
 
     StreamBinding binding(ProducerBinding producerBinding);
-  }
-
-  interface StatusResolver extends GraphQLResolver<Status>, GraphQLApiType {
-    ObjectNode getAgentStatus(com.expediagroup.streamplatform.streamregistry.model.Status status);
   }
 
   interface EntityResolver<E extends Entity> {

--- a/graphql/api/src/main/resources/stream-registry.graphql
+++ b/graphql/api/src/main/resources/stream-registry.graphql
@@ -4,14 +4,37 @@ scalar ObjectNode
 
 input StatusInput {
     agentStatus: ObjectNode!
+    entries: [StatusEntryInput!]
+}
+
+input StatusEntryInput {
+    name: String!
+    state: StatusState!
+    context: ObjectNode!
 }
 
 input StatusQuery {
     descriptionRegex: String
+    nameRegex: String
 }
 
 type Status {
     agentStatus: ObjectNode!
+    entries: [StatusEntry!]
+}
+
+type StatusEntry {
+    name: String!
+    timestamp: String!
+    state: StatusState!
+    context: ObjectNode!
+}
+
+enum StatusState {
+    PENDING
+    OK
+    ERROR
+    UNDEFINED
 }
 
 ############ Tag ############

--- a/graphql/api/src/main/resources/stream-registry.graphql
+++ b/graphql/api/src/main/resources/stream-registry.graphql
@@ -25,7 +25,8 @@ type Status {
 
 type StatusEntry {
     name: String!
-    timestamp: String!
+    createdTs: String!
+    updatedTs: String!
     state: StatusState!
     context: ObjectNode!
 }
@@ -102,6 +103,8 @@ type Specification {
     type: String!
     configuration: ObjectNode!
     security: [Security!]!
+    createdTs: String!
+    updatedTs: String!
 }
 
 ############ Domain ############

--- a/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/model/inputs/SpecificationInputTest.java
+++ b/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/model/inputs/SpecificationInputTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2020 Expedia, Inc.
+ * Copyright (C) 2018-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,19 @@
  */
 package com.expediagroup.streamplatform.streamregistry.graphql.model.inputs;
 
-import com.expediagroup.streamplatform.streamregistry.model.Principal;
-import com.expediagroup.streamplatform.streamregistry.model.Security;
-import com.expediagroup.streamplatform.streamregistry.model.Specification;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.util.Collections;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+import com.expediagroup.streamplatform.streamregistry.model.Principal;
+import com.expediagroup.streamplatform.streamregistry.model.Security;
+import com.expediagroup.streamplatform.streamregistry.model.Specification;
 
 public class SpecificationInputTest {
   private final ObjectMapper mapper = new ObjectMapper();

--- a/model/src/main/java/com/expediagroup/streamplatform/streamregistry/model/StatusEntry.java
+++ b/model/src/main/java/com/expediagroup/streamplatform/streamregistry/model/StatusEntry.java
@@ -15,25 +15,34 @@
  */
 package com.expediagroup.streamplatform.streamregistry.model;
 
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.unmodifiableMap;
+import java.time.Instant;
 
-import java.util.Map;
-
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+@Data
 @NoArgsConstructor
+@AllArgsConstructor
 @EqualsAndHashCode
-public class Status {
+public class StatusEntry {
+  private String name;
+  private ObjectNode value;
+  private Instant timestamp;
+  private StatusEntry.State state;
 
-  private Map<String, StatusEntry> entries;
-
-  public Status(Map<String, StatusEntry> entries) {
-    this.entries = unmodifiableMap(entries);
+  public ObjectNode getValue() {
+    return value == null ? new ObjectMapper().createObjectNode() : value;
   }
 
-  public Map<String, StatusEntry> getEntries() {
-    return entries == null ? emptyMap() : entries;
+  public enum State {
+    PENDING,
+    OK,
+    ERROR,
+    UNDEFINED
   }
 }

--- a/model/src/main/java/com/expediagroup/streamplatform/streamregistry/model/StatusEntry.java
+++ b/model/src/main/java/com/expediagroup/streamplatform/streamregistry/model/StatusEntry.java
@@ -32,8 +32,17 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public class StatusEntry {
   private String name;
   private ObjectNode value;
-  private Instant timestamp;
+  private Instant createdTs;
+  private Instant updatedTs;
   private StatusEntry.State state;
+
+  public StatusEntry(
+    String name,
+    ObjectNode value,
+    StatusEntry.State state
+  ) {
+    this(name, value, null, null, state);
+  }
 
   public ObjectNode getValue() {
     return value == null ? new ObjectMapper().createObjectNode() : value;

--- a/repository/kafka/src/main/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/Converter.java
+++ b/repository/kafka/src/main/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/Converter.java
@@ -114,7 +114,8 @@ interface Converter<ME extends com.expediagroup.streamplatform.streamregistry.mo
           e -> new com.expediagroup.streamplatform.streamregistry.model.StatusEntry(
             e.getName(),
             e.getValue(),
-            e.getTimestamp(),
+            e.getCreatedTs(),
+            e.getUpdatedTs(),
             com.expediagroup.streamplatform.streamregistry.model.StatusEntry.State.valueOf(e.getState().name())
           )
         ))
@@ -126,7 +127,8 @@ interface Converter<ME extends com.expediagroup.streamplatform.streamregistry.mo
           e -> new StatusEntry(
             e.getName(),
             e.getValue(),
-            e.getTimestamp(),
+            e.getCreatedTs(),
+            e.getUpdatedTs(),
             StatusEntry.State.valueOf(e.getState().name())
           )
         ).collect(toList());

--- a/repository/kafka/src/test/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/DefaultRepositoryTest.java
+++ b/repository/kafka/src/test/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/DefaultRepositoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2020 Expedia, Inc.
+ * Copyright (C) 2018-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -66,8 +67,12 @@ public class DefaultRepositoryTest {
   public void saveExistingSpecificationAndStatus() {
     Entity<Entity.DomainKey, DefaultSpecification> domain = SampleState.domain();
     domain = domain.withSpecification(domain.getSpecification().withDescription("old description"));
-    domain = domain.withStatus(new DefaultStatus().with(new StatusEntry("agentStatus", mapper
-        .createObjectNode().put("foo", "bar"))));
+    domain = domain.withStatus(new DefaultStatus().with(new StatusEntry(
+      "agentStatus",
+      mapper.createObjectNode().put("foo", "bar"),
+      Instant.EPOCH,
+      StatusEntry.State.UNDEFINED
+    )));
 
     when(view.get(SampleState.domainKey())).thenReturn(Optional.of(domain));
 
@@ -81,7 +86,12 @@ public class DefaultRepositoryTest {
     Entity<Entity.DomainKey, DefaultSpecification> expected = SampleState.domain();
 
     verify(sender).send(Event.specification(expected.getKey(), expected.getSpecification()));
-    verify(sender).send(Event.status(expected.getKey(), new StatusEntry("agentStatus", mapper.createObjectNode())));
+    verify(sender).send(Event.status(expected.getKey(), new StatusEntry(
+      "agentStatus",
+      mapper.createObjectNode(),
+      Instant.EPOCH,
+      StatusEntry.State.UNDEFINED
+    )));
   }
 
   @Test
@@ -100,14 +110,23 @@ public class DefaultRepositoryTest {
     Entity<Entity.DomainKey, DefaultSpecification> expected = SampleState.domain();
 
     verify(sender).send(Event.specification(expected.getKey(), expected.getSpecification()));
-    verify(sender, never()).send(Event.status(expected.getKey(), new StatusEntry("agentStatus", mapper.createObjectNode())));
+    verify(sender, never()).send(Event.status(expected.getKey(), new StatusEntry(
+      "agentStatus",
+      mapper.createObjectNode(),
+      Instant.EPOCH,
+      StatusEntry.State.UNDEFINED
+    )));
   }
 
   @Test
   public void saveExistingStatusOnly() {
     Entity<Entity.DomainKey, DefaultSpecification> domain = SampleState.domain();
-    domain = domain.withStatus(new DefaultStatus().with(new StatusEntry("agentStatus", mapper
-        .createObjectNode().put("foo", "bar"))));
+    domain = domain.withStatus(new DefaultStatus().with(new StatusEntry(
+      "agentStatus",
+      mapper.createObjectNode().put("foo", "bar"),
+      Instant.EPOCH,
+      StatusEntry.State.UNDEFINED
+    )));
 
     when(view.get(SampleState.domainKey())).thenReturn(Optional.of(domain));
 
@@ -120,7 +139,12 @@ public class DefaultRepositoryTest {
     Entity<Entity.DomainKey, DefaultSpecification> expected = SampleState.domain();
 
     verify(sender, never()).send(Event.specification(expected.getKey(), expected.getSpecification()));
-    verify(sender).send(Event.status(expected.getKey(), new StatusEntry("agentStatus", mapper.createObjectNode())));
+    verify(sender).send(Event.status(expected.getKey(), new StatusEntry(
+      "agentStatus",
+      mapper.createObjectNode(),
+      Instant.EPOCH,
+      StatusEntry.State.UNDEFINED
+    )));
   }
 
   @Test
@@ -137,7 +161,12 @@ public class DefaultRepositoryTest {
     Entity<Entity.DomainKey, DefaultSpecification> expected = SampleState.domain();
 
     verify(sender).send(Event.specification(expected.getKey(), expected.getSpecification()));
-    verify(sender).send(Event.status(expected.getKey(), new StatusEntry("agentStatus", mapper.createObjectNode())));
+    verify(sender).send(Event.status(expected.getKey(), new StatusEntry(
+      "agentStatus",
+      mapper.createObjectNode().put("foo", "bar"),
+      Instant.EPOCH,
+      StatusEntry.State.UNDEFINED
+    )));
   }
 
   @Test

--- a/repository/kafka/src/test/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/DefaultRepositoryTest.java
+++ b/repository/kafka/src/test/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/DefaultRepositoryTest.java
@@ -71,6 +71,7 @@ public class DefaultRepositoryTest {
       "agentStatus",
       mapper.createObjectNode().put("foo", "bar"),
       Instant.EPOCH,
+      Instant.EPOCH,
       StatusEntry.State.UNDEFINED
     )));
 
@@ -89,6 +90,7 @@ public class DefaultRepositoryTest {
     verify(sender).send(Event.status(expected.getKey(), new StatusEntry(
       "agentStatus",
       mapper.createObjectNode(),
+      Instant.EPOCH,
       Instant.EPOCH,
       StatusEntry.State.UNDEFINED
     )));
@@ -114,6 +116,7 @@ public class DefaultRepositoryTest {
       "agentStatus",
       mapper.createObjectNode(),
       Instant.EPOCH,
+      Instant.EPOCH,
       StatusEntry.State.UNDEFINED
     )));
   }
@@ -124,6 +127,7 @@ public class DefaultRepositoryTest {
     domain = domain.withStatus(new DefaultStatus().with(new StatusEntry(
       "agentStatus",
       mapper.createObjectNode().put("foo", "bar"),
+      Instant.EPOCH,
       Instant.EPOCH,
       StatusEntry.State.UNDEFINED
     )));
@@ -142,6 +146,7 @@ public class DefaultRepositoryTest {
     verify(sender).send(Event.status(expected.getKey(), new StatusEntry(
       "agentStatus",
       mapper.createObjectNode(),
+      Instant.EPOCH,
       Instant.EPOCH,
       StatusEntry.State.UNDEFINED
     )));
@@ -164,6 +169,7 @@ public class DefaultRepositoryTest {
     verify(sender).send(Event.status(expected.getKey(), new StatusEntry(
       "agentStatus",
       mapper.createObjectNode().put("foo", "bar"),
+      Instant.EPOCH,
       Instant.EPOCH,
       StatusEntry.State.UNDEFINED
     )));

--- a/repository/kafka/src/test/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/DefaultRepositoryTest.java
+++ b/repository/kafka/src/test/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/DefaultRepositoryTest.java
@@ -168,7 +168,7 @@ public class DefaultRepositoryTest {
     verify(sender).send(Event.specification(expected.getKey(), expected.getSpecification()));
     verify(sender).send(Event.status(expected.getKey(), new StatusEntry(
       "agentStatus",
-      mapper.createObjectNode().put("foo", "bar"),
+      mapper.createObjectNode(),
       Instant.EPOCH,
       Instant.EPOCH,
       StatusEntry.State.UNDEFINED

--- a/repository/kafka/src/test/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/SampleModel.java
+++ b/repository/kafka/src/test/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/SampleModel.java
@@ -75,6 +75,7 @@ final class SampleModel {
         "agentStatus",
         new ObjectMapper().createObjectNode(),
         Instant.EPOCH,
+        Instant.EPOCH,
         StatusEntry.State.UNDEFINED
       )
     ));

--- a/repository/kafka/src/test/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/SampleModel.java
+++ b/repository/kafka/src/test/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/SampleModel.java
@@ -16,7 +16,11 @@
 package com.expediagroup.streamplatform.streamregistry.repository.kafka;
 
 
-import java.util.*;
+import static java.util.Collections.singletonMap;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -31,6 +35,7 @@ import com.expediagroup.streamplatform.streamregistry.model.Schema;
 import com.expediagroup.streamplatform.streamregistry.model.Security;
 import com.expediagroup.streamplatform.streamregistry.model.Specification;
 import com.expediagroup.streamplatform.streamregistry.model.Status;
+import com.expediagroup.streamplatform.streamregistry.model.StatusEntry;
 import com.expediagroup.streamplatform.streamregistry.model.Stream;
 import com.expediagroup.streamplatform.streamregistry.model.StreamBinding;
 import com.expediagroup.streamplatform.streamregistry.model.Tag;
@@ -64,7 +69,15 @@ final class SampleModel {
   }
 
   static Status status() {
-    return new Status(mapper.createObjectNode());
+    return new Status(singletonMap(
+      "agentStatus",
+      new StatusEntry(
+        "agentStatus",
+        new ObjectMapper().createObjectNode(),
+        Instant.EPOCH,
+        StatusEntry.State.UNDEFINED
+      )
+    ));
   }
 
   static DomainKey domainKey() {

--- a/repository/kafka/src/test/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/SampleState.java
+++ b/repository/kafka/src/test/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/SampleState.java
@@ -16,8 +16,10 @@
 package com.expediagroup.streamplatform.streamregistry.repository.kafka;
 
 
+import static java.util.Collections.singletonList;
+
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -50,7 +52,7 @@ final class SampleState {
   private static DefaultSpecification specification() {
     return new DefaultSpecification(
       "description",
-      Collections.singletonList(new com.expediagroup.streamplatform.streamregistry.state.model.specification.Tag("name", "value")),
+      singletonList(new com.expediagroup.streamplatform.streamregistry.state.model.specification.Tag("name", "value")),
       "type",
       mapper.createObjectNode(),
       new HashMap<String, List<Principal>>() {{
@@ -62,7 +64,7 @@ final class SampleState {
   static StreamSpecification streamSpecification() {
     return new StreamSpecification(
       "description",
-      Collections.singletonList(new com.expediagroup.streamplatform.streamregistry.state.model.specification.Tag("name", "value")),
+      singletonList(new com.expediagroup.streamplatform.streamregistry.state.model.specification.Tag("name", "value")),
       "type",
       mapper.createObjectNode(),
       new HashMap<String, List<Principal>>() {{
@@ -73,7 +75,9 @@ final class SampleState {
   }
 
   static DefaultStatus status() {
-    return new DefaultStatus().with(new StatusEntry("agentStatus", mapper.createObjectNode()));
+    return new DefaultStatus().with(
+      new StatusEntry("agentStatus", mapper.createObjectNode(), Instant.EPOCH, StatusEntry.State.UNDEFINED)
+    );
   }
 
   static DomainKey domainKey() {
@@ -169,6 +173,9 @@ final class SampleState {
   }
 
   static Event<DomainKey, DefaultSpecification> domainStatusEvent() {
-    return Event.status(domainKey(), new StatusEntry("agentStatus", mapper.createObjectNode()));
+    return Event.status(
+      domainKey(),
+      new StatusEntry("agentStatus", mapper.createObjectNode(), Instant.EPOCH, StatusEntry.State.UNDEFINED)
+    );
   }
 }

--- a/repository/kafka/src/test/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/SampleState.java
+++ b/repository/kafka/src/test/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/SampleState.java
@@ -76,7 +76,7 @@ final class SampleState {
 
   static DefaultStatus status() {
     return new DefaultStatus().with(
-      new StatusEntry("agentStatus", mapper.createObjectNode(), Instant.EPOCH, StatusEntry.State.UNDEFINED)
+      new StatusEntry("agentStatus", mapper.createObjectNode(), Instant.EPOCH, Instant.EPOCH, StatusEntry.State.UNDEFINED)
     );
   }
 
@@ -175,7 +175,7 @@ final class SampleState {
   static Event<DomainKey, DefaultSpecification> domainStatusEvent() {
     return Event.status(
       domainKey(),
-      new StatusEntry("agentStatus", mapper.createObjectNode(), Instant.EPOCH, StatusEntry.State.UNDEFINED)
+      new StatusEntry("agentStatus", mapper.createObjectNode(), Instant.EPOCH, Instant.EPOCH, StatusEntry.State.UNDEFINED)
     );
   }
 }

--- a/state/api/src/main/java/com/expediagroup/streamplatform/streamregistry/state/model/status/Status.java
+++ b/state/api/src/main/java/com/expediagroup/streamplatform/streamregistry/state/model/status/Status.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2020 Expedia, Inc.
+ * Copyright (C) 2018-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,14 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public interface Status {
   Set<String> getNames();
 
+  @Deprecated
   ObjectNode getValue(@NonNull String name);
 
+  StatusEntry getStatusEntryByName(@NonNull String name);
+
   List<StatusEntry> getEntries();
+
+  DefaultStatus withAll(@NonNull List<StatusEntry> entries);
 
   Status with(@NonNull StatusEntry entry);
 

--- a/state/api/src/main/java/com/expediagroup/streamplatform/streamregistry/state/model/status/StatusEntry.java
+++ b/state/api/src/main/java/com/expediagroup/streamplatform/streamregistry/state/model/status/StatusEntry.java
@@ -26,7 +26,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public class StatusEntry {
   @NonNull String name;
   @NonNull ObjectNode value;
-  @NonNull Instant timestamp;
+  @NonNull Instant createdTs;
+  @NonNull Instant updatedTs;
   @NonNull State state;
 
   public enum State {

--- a/state/api/src/main/java/com/expediagroup/streamplatform/streamregistry/state/model/status/StatusEntry.java
+++ b/state/api/src/main/java/com/expediagroup/streamplatform/streamregistry/state/model/status/StatusEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2020 Expedia, Inc.
+ * Copyright (C) 2018-2021 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package com.expediagroup.streamplatform.streamregistry.state.model.status;
 
+import java.time.Instant;
+
 import lombok.NonNull;
 import lombok.Value;
 
@@ -24,4 +26,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public class StatusEntry {
   @NonNull String name;
   @NonNull ObjectNode value;
+  @NonNull Instant timestamp;
+  @NonNull State state;
+
+  public enum State {
+    PENDING, OK, ERROR, UNDEFINED
+  }
 }

--- a/state/avro/src/main/java/com/expediagroup/streamplatform/streamregistry/state/avro/AvroConverter.java
+++ b/state/avro/src/main/java/com/expediagroup/streamplatform/streamregistry/state/avro/AvroConverter.java
@@ -174,9 +174,10 @@ public class AvroConverter {
         return Event.statusDeletion(key, statusName);
       }
       val statusValue = convertObject(avroStatus.getValue(), ObjectNode.class);
-      val statusTimestamp = Instant.ofEpochMilli(avroStatus.getTimestamp());
+      val statusCreatedTs = Instant.ofEpochMilli(avroStatus.getCreatedTs());
+      val statusUpdatedTs = Instant.ofEpochMilli(avroStatus.getUpdatedTs());
       val statusState = StatusEntry.State.valueOf(avroStatus.getState().name());
-      return Event.status(key, new StatusEntry(statusName, statusValue, statusTimestamp, statusState));
+      return Event.status(key, new StatusEntry(statusName, statusValue, statusCreatedTs, statusUpdatedTs, statusState));
     }
 
     private AvroEvent toAvro(SpecificationEvent<?, ?> event) {
@@ -192,11 +193,12 @@ public class AvroConverter {
       val key = convertObject(event.getKey(), avroKeyClass);
       val statusName = event.getStatusEntry().getName();
       val statusValue = convertObject(event.getStatusEntry().getValue(), AvroObject.class);
-      val statusTimestamp = event.getStatusEntry().getTimestamp().toEpochMilli();
+      val statusCreatedTs = event.getStatusEntry().getCreatedTs().toEpochMilli();
+      val statusUpdatedTs = event.getStatusEntry().getUpdatedTs().toEpochMilli();
       val statusState = AvroStatusState.valueOf(event.getStatusEntry().getState().name());
       return new AvroEvent(
         new AvroKey(new AvroStatusKey(key, statusName)),
-        new AvroValue(new AvroStatus(statusValue, statusTimestamp, statusState))
+        new AvroValue(new AvroStatus(statusValue, statusCreatedTs, statusUpdatedTs, statusState))
       );
     }
 

--- a/state/avro/src/main/resources/avro/stream-registry.avdl
+++ b/state/avro/src/main/resources/avro/stream-registry.avdl
@@ -74,8 +74,6 @@ protocol StreamRegistry {
     string type;
     AvroObject configuration;
     map<array<AvroPrincipal>> security = {};
-    long createdTs = 0;
-    long updatedTs = 0;
   }
 
   record AvroStreamSpecification {
@@ -85,8 +83,6 @@ protocol StreamRegistry {
     AvroObject configuration;
     map<array<AvroPrincipal>> security = {};
     AvroSchemaKey schemaKey;
-    long createdTs = 0;
-    long updatedTs = 0;
   }
 
   record AvroSpecificationKey {

--- a/state/avro/src/main/resources/avro/stream-registry.avdl
+++ b/state/avro/src/main/resources/avro/stream-registry.avdl
@@ -96,6 +96,12 @@ protocol StreamRegistry {
 
   record AvroStatus {
     AvroObject value;
+    long timestamp = 0;
+    AvroStatusState state = "UNDEFINED";
+  }
+
+  enum AvroStatusState {
+    PENDING, OK, ERROR, UNDEFINED
   }
 
   record AvroKey {

--- a/state/avro/src/main/resources/avro/stream-registry.avdl
+++ b/state/avro/src/main/resources/avro/stream-registry.avdl
@@ -74,6 +74,8 @@ protocol StreamRegistry {
     string type;
     AvroObject configuration;
     map<array<AvroPrincipal>> security = {};
+    long createdTs = 0;
+    long updatedTs = 0;
   }
 
   record AvroStreamSpecification {
@@ -83,6 +85,8 @@ protocol StreamRegistry {
     AvroObject configuration;
     map<array<AvroPrincipal>> security = {};
     AvroSchemaKey schemaKey;
+    long createdTs = 0;
+    long updatedTs = 0;
   }
 
   record AvroSpecificationKey {
@@ -96,7 +100,8 @@ protocol StreamRegistry {
 
   record AvroStatus {
     AvroObject value;
-    long timestamp = 0;
+    long createdTs = 0;
+    long updatedTs = 0;
     AvroStatusState state = "UNDEFINED";
   }
 

--- a/state/avro/src/test/java/com/expediagroup/streamplatform/streamregistry/state/avro/AvroConverterTest.java
+++ b/state/avro/src/test/java/com/expediagroup/streamplatform/streamregistry/state/avro/AvroConverterTest.java
@@ -59,7 +59,9 @@ public class AvroConverterTest {
       new HashMap<String, List<AvroPrincipal>>() {{
         put("admin", Arrays.asList(new AvroPrincipal("user1")));
         put("creator", Arrays.asList(new AvroPrincipal("user2"), new AvroPrincipal("user3")));
-      }}
+      }},
+    0L,
+    0L
   );
   private final AvroStreamSpecification avroStreamSpecification = new AvroStreamSpecification(
       "description",
@@ -70,12 +72,14 @@ public class AvroConverterTest {
         put("admin", Arrays.asList(new AvroPrincipal("user1")));
         put("creator", Arrays.asList(new AvroPrincipal("user2"), new AvroPrincipal("user3")));
       }},
-      new AvroSchemaKey(avroDomainKey, "schema")
+      new AvroSchemaKey(avroDomainKey, "schema"),
+    0L,
+    0L
   );
 
   private final AvroStatusKey avroStatusKey = new AvroStatusKey(avroDomainKey, "statusName");
   private final AvroObject avroObjectStatus = new AvroObject(Collections.singletonMap("foo", "baz"));
-  private final AvroStatus avroStatus = new AvroStatus(avroObjectStatus, 1L, AvroStatusState.OK);
+  private final AvroStatus avroStatus = new AvroStatus(avroObjectStatus, 1L, 1L, AvroStatusState.OK);
 
   private final AvroEvent avroSpecificationEvent = new AvroEvent(new AvroKey(avroSpecificationKey), new AvroValue(avroSpecification));
   private final AvroEvent avroStreamSpecificationEvent = new AvroEvent(new AvroKey(new AvroSpecificationKey(avroStreamKey)), new AvroValue(avroStreamSpecification));
@@ -92,11 +96,14 @@ public class AvroConverterTest {
       new HashMap<String, List<Principal>>() {{
         put("admin", Arrays.asList(new Principal("user1")));
         put("creator", Arrays.asList(new Principal("user2"), new Principal("user3")));
-      }}
+      }},
+    Instant.ofEpochMilli(1L),
+    Instant.ofEpochMilli(1L)
   );
   private final StatusEntry statusEntry = new StatusEntry(
     "statusName",
     mapper.createObjectNode().put("foo", "baz"),
+    Instant.ofEpochMilli(1L),
     Instant.ofEpochMilli(1L),
     StatusEntry.State.OK
   );
@@ -110,7 +117,9 @@ public class AvroConverterTest {
         put("admin", Arrays.asList(new Principal("user1")));
         put("creator", Arrays.asList(new Principal("user2"), new Principal("user3")));
       }},
-      new Entity.SchemaKey(domainKey, "schema")
+      new Entity.SchemaKey(domainKey, "schema"),
+    Instant.ofEpochMilli(1L),
+    Instant.ofEpochMilli(1L)
   );
 
   @Test

--- a/state/avro/src/test/java/com/expediagroup/streamplatform/streamregistry/state/avro/AvroConverterTest.java
+++ b/state/avro/src/test/java/com/expediagroup/streamplatform/streamregistry/state/avro/AvroConverterTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -74,7 +75,7 @@ public class AvroConverterTest {
 
   private final AvroStatusKey avroStatusKey = new AvroStatusKey(avroDomainKey, "statusName");
   private final AvroObject avroObjectStatus = new AvroObject(Collections.singletonMap("foo", "baz"));
-  private final AvroStatus avroStatus = new AvroStatus(avroObjectStatus);
+  private final AvroStatus avroStatus = new AvroStatus(avroObjectStatus, 1L, AvroStatusState.OK);
 
   private final AvroEvent avroSpecificationEvent = new AvroEvent(new AvroKey(avroSpecificationKey), new AvroValue(avroSpecification));
   private final AvroEvent avroStreamSpecificationEvent = new AvroEvent(new AvroKey(new AvroSpecificationKey(avroStreamKey)), new AvroValue(avroStreamSpecification));
@@ -93,7 +94,12 @@ public class AvroConverterTest {
         put("creator", Arrays.asList(new Principal("user2"), new Principal("user3")));
       }}
   );
-  private final StatusEntry statusEntry = new StatusEntry("statusName", mapper.createObjectNode().put("foo", "baz"));
+  private final StatusEntry statusEntry = new StatusEntry(
+    "statusName",
+    mapper.createObjectNode().put("foo", "baz"),
+    Instant.ofEpochMilli(1L),
+    StatusEntry.State.OK
+  );
   private final StreamKey streamKey = new StreamKey(domainKey, "stream", 1);
   private final StreamSpecification streamSpecification = new StreamSpecification(
       "description",

--- a/state/avro/src/test/java/com/expediagroup/streamplatform/streamregistry/state/avro/AvroConverterTest.java
+++ b/state/avro/src/test/java/com/expediagroup/streamplatform/streamregistry/state/avro/AvroConverterTest.java
@@ -59,9 +59,7 @@ public class AvroConverterTest {
       new HashMap<String, List<AvroPrincipal>>() {{
         put("admin", Arrays.asList(new AvroPrincipal("user1")));
         put("creator", Arrays.asList(new AvroPrincipal("user2"), new AvroPrincipal("user3")));
-      }},
-    0L,
-    0L
+      }}
   );
   private final AvroStreamSpecification avroStreamSpecification = new AvroStreamSpecification(
       "description",
@@ -72,9 +70,7 @@ public class AvroConverterTest {
         put("admin", Arrays.asList(new AvroPrincipal("user1")));
         put("creator", Arrays.asList(new AvroPrincipal("user2"), new AvroPrincipal("user3")));
       }},
-      new AvroSchemaKey(avroDomainKey, "schema"),
-    0L,
-    0L
+      new AvroSchemaKey(avroDomainKey, "schema")
   );
 
   private final AvroStatusKey avroStatusKey = new AvroStatusKey(avroDomainKey, "statusName");
@@ -96,9 +92,7 @@ public class AvroConverterTest {
       new HashMap<String, List<Principal>>() {{
         put("admin", Arrays.asList(new Principal("user1")));
         put("creator", Arrays.asList(new Principal("user2"), new Principal("user3")));
-      }},
-    Instant.ofEpochMilli(1L),
-    Instant.ofEpochMilli(1L)
+      }}
   );
   private final StatusEntry statusEntry = new StatusEntry(
     "statusName",
@@ -117,9 +111,7 @@ public class AvroConverterTest {
         put("admin", Arrays.asList(new Principal("user1")));
         put("creator", Arrays.asList(new Principal("user2"), new Principal("user3")));
       }},
-      new Entity.SchemaKey(domainKey, "schema"),
-    Instant.ofEpochMilli(1L),
-    Instant.ofEpochMilli(1L)
+      new Entity.SchemaKey(domainKey, "schema")
   );
 
   @Test

--- a/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/SampleEntities.java
+++ b/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/SampleEntities.java
@@ -37,9 +37,21 @@ final class SampleEntities {
   static final ObjectMapper mapper = new ObjectMapper();
   static final ObjectNode configuration = mapper.createObjectNode();
   static final DomainKey key = new DomainKey("domain");
-  static final DefaultSpecification specification = new DefaultSpecification("description", Collections.emptyList(), "type", configuration, Collections.emptyMap());
+  static final DefaultSpecification specification = new DefaultSpecification(
+    "description",
+    Collections.emptyList(),
+    "type",
+    configuration,
+    Collections.emptyMap()
+  );
   static final ObjectNode statusValue = mapper.createObjectNode();
-  static final StatusEntry statusEntry = new StatusEntry("name", statusValue, Instant.ofEpochMilli(0L), OK);
+  static final StatusEntry statusEntry = new StatusEntry(
+    "name",
+    statusValue,
+    Instant.ofEpochMilli(0L),
+    Instant.ofEpochMilli(0L),
+    OK
+  );
   static final DefaultStatus status = new DefaultStatus().with(statusEntry);
   static final Entity<DomainKey, DefaultSpecification> entity = new Entity<>(key, specification, status);
   static final Event<DomainKey, DefaultSpecification> specificationEvent = Event.specification(key, specification);

--- a/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/SampleEntities.java
+++ b/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/SampleEntities.java
@@ -16,6 +16,9 @@
 package com.expediagroup.streamplatform.streamregistry.state;
 
 
+import static com.expediagroup.streamplatform.streamregistry.state.model.status.StatusEntry.State.OK;
+
+import java.time.Instant;
 import java.util.Collections;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -36,7 +39,7 @@ final class SampleEntities {
   static final DomainKey key = new DomainKey("domain");
   static final DefaultSpecification specification = new DefaultSpecification("description", Collections.emptyList(), "type", configuration, Collections.emptyMap());
   static final ObjectNode statusValue = mapper.createObjectNode();
-  static final StatusEntry statusEntry = new StatusEntry("name", statusValue);
+  static final StatusEntry statusEntry = new StatusEntry("name", statusValue, Instant.ofEpochMilli(0L), OK);
   static final DefaultStatus status = new DefaultStatus().with(statusEntry);
   static final Entity<DomainKey, DefaultSpecification> entity = new Entity<>(key, specification, status);
   static final Event<DomainKey, DefaultSpecification> specificationEvent = Event.specification(key, specification);

--- a/state/graphql-sender/src/test/java/com/expediagroup/streamplatform/streamregistry/state/graphql/GraphQLConverterTest.java
+++ b/state/graphql-sender/src/test/java/com/expediagroup/streamplatform/streamregistry/state/graphql/GraphQLConverterTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -66,7 +67,12 @@ public class GraphQLConverterTest {
   }};
   private final DefaultSpecification specification = new DefaultSpecification("description", Collections.singletonList(tag), "type", configuration, security);
   private final StreamSpecification streamSpecification = new StreamSpecification("description", Collections.singletonList(tag), "type", configuration, security, schemaKey);
-  private final StatusEntry statusEntry = new StatusEntry("agentStatus", mapper.createObjectNode());
+  private final StatusEntry statusEntry = new StatusEntry(
+    "agentStatus",
+    mapper.createObjectNode(),
+    Instant.EPOCH,
+    StatusEntry.State.UNDEFINED
+  );
 
   @Test(expected = IllegalArgumentException.class)
   public void unknownKey() {
@@ -86,7 +92,12 @@ public class GraphQLConverterTest {
 
   @Test(expected = UnsupportedOperationException.class)
   public void unsupportedStatusName() {
-    underTest.convert(Event.status(domainKey, new StatusEntry("foo", mapper.createObjectNode())));
+    underTest.convert(Event.status(domainKey, new StatusEntry(
+      "foo",
+      mapper.createObjectNode(),
+      Instant.EPOCH,
+      StatusEntry.State.UNDEFINED
+    )));
   }
 
   @Test

--- a/state/graphql-sender/src/test/java/com/expediagroup/streamplatform/streamregistry/state/graphql/GraphQLConverterTest.java
+++ b/state/graphql-sender/src/test/java/com/expediagroup/streamplatform/streamregistry/state/graphql/GraphQLConverterTest.java
@@ -65,11 +65,25 @@ public class GraphQLConverterTest {
     put("admin", Arrays.asList(new Principal("user1")));
     put("creator", Arrays.asList(new Principal("user2"), new Principal("user3")));
   }};
-  private final DefaultSpecification specification = new DefaultSpecification("description", Collections.singletonList(tag), "type", configuration, security);
-  private final StreamSpecification streamSpecification = new StreamSpecification("description", Collections.singletonList(tag), "type", configuration, security, schemaKey);
+  private final DefaultSpecification specification = new DefaultSpecification(
+    "description",
+    Collections.singletonList(tag),
+    "type",
+    configuration,
+    security
+  );
+  private final StreamSpecification streamSpecification = new StreamSpecification(
+    "description",
+    Collections.singletonList(tag),
+    "type",
+    configuration,
+    security,
+    schemaKey
+  );
   private final StatusEntry statusEntry = new StatusEntry(
     "agentStatus",
     mapper.createObjectNode(),
+    Instant.EPOCH,
     Instant.EPOCH,
     StatusEntry.State.UNDEFINED
   );
@@ -95,6 +109,7 @@ public class GraphQLConverterTest {
     underTest.convert(Event.status(domainKey, new StatusEntry(
       "foo",
       mapper.createObjectNode(),
+      Instant.EPOCH,
       Instant.EPOCH,
       StatusEntry.State.UNDEFINED
     )));

--- a/state/it/src/test/java/com/expediagroup/streamplatform/streamregistry/state/it/StateIT.java
+++ b/state/it/src/test/java/com/expediagroup/streamplatform/streamregistry/state/it/StateIT.java
@@ -65,6 +65,7 @@ public class StateIT {
     "statusName",
     statusValue,
     Instant.ofEpochMilli(1L),
+    Instant.ofEpochMilli(1L),
     StatusEntry.State.OK
   );
   private final Event<DomainKey, DefaultSpecification> specificationEvent = Event.specification(key, specification);

--- a/state/kafka-sender/src/test/java/com/expediagroup/streamplatform/streamregistry/state/kafka/KafkaEventSenderTest.java
+++ b/state/kafka-sender/src/test/java/com/expediagroup/streamplatform/streamregistry/state/kafka/KafkaEventSenderTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -69,7 +70,13 @@ public class KafkaEventSenderTest {
     put("admin", Arrays.asList(new Principal("user1")));
     put("creator", Arrays.asList(new Principal("user2"), new Principal("user3")));
   }};
-  private final DefaultSpecification specification = new DefaultSpecification("description", Collections.emptyList(), "type", mapper.createObjectNode(), security);
+  private final DefaultSpecification specification = new DefaultSpecification(
+    "description",
+    Collections.emptyList(),
+    "type",
+    mapper.createObjectNode(),
+    security
+  );
   private final Event<DomainKey, DefaultSpecification> event = Event.specification(key, specification);
 
   @Mock private AvroEvent avroEvent;

--- a/state/kafka-sender/src/test/java/com/expediagroup/streamplatform/streamregistry/state/kafka/KafkaEventSenderTest.java
+++ b/state/kafka-sender/src/test/java/com/expediagroup/streamplatform/streamregistry/state/kafka/KafkaEventSenderTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;


### PR DESCRIPTION
# stream-registry PR

This PR allows entities to have multiple statuses keyed on a name. Additionally, statuses have been enhanced to include a timestamp of when they were create and updated, and also a state of `PENDING`, `OK`, `ERROR`, and `UNDEFINED`. The first 3 states model outcomes in a simple state machine, whereas UNDEFINED applies only to legacy statuses. We retain the older `agentStatus` behaviour for compatibility.

This new model will both allow for:
* more complex orchestration between agents
* a means to persist and track creation and modification timestamps of statuses 
* a means to implement optimistic locking

Later PRs:
* Add create/update TS to specification
* Set created/updated values on specifications and statuses in GQL endpoint
* Accept and check correlation TS in GQL mutations

# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [x] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation) 
