### PR TITLE
Stream Registry state metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [unreleased]
 ### Added
+- Added option to add metrics to `EntityView`
+
+## [0.20.6] 2022-01-12
+### Added
 - added arbitrary property support for repostiry kafka event receiver/sender
 
 ## [0.20.5] 2022-01-07

--- a/state/core/pom.xml
+++ b/state/core/pom.xml
@@ -31,6 +31,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/state/core/src/main/java/com/expediagroup/streamplatform/streamregistry/state/DefaultEntityView.java
+++ b/state/core/src/main/java/com/expediagroup/streamplatform/streamregistry/state/DefaultEntityView.java
@@ -15,8 +15,13 @@
  */
 package com.expediagroup.streamplatform.streamregistry.state;
 
-import static com.expediagroup.streamplatform.streamregistry.state.model.event.Event.LOAD_COMPLETE;
-import static lombok.AccessLevel.PACKAGE;
+import com.expediagroup.streamplatform.streamregistry.state.model.Entity;
+import com.expediagroup.streamplatform.streamregistry.state.model.event.Event;
+import com.expediagroup.streamplatform.streamregistry.state.model.specification.Specification;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
 
 import java.util.Map;
 import java.util.Optional;
@@ -25,23 +30,20 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.val;
-
-import com.expediagroup.streamplatform.streamregistry.state.model.Entity;
-import com.expediagroup.streamplatform.streamregistry.state.model.event.Event;
-import com.expediagroup.streamplatform.streamregistry.state.model.specification.Specification;
+import static com.expediagroup.streamplatform.streamregistry.state.model.event.Event.LOAD_COMPLETE;
+import static lombok.AccessLevel.PACKAGE;
 
 @RequiredArgsConstructor(access = PACKAGE)
 public class DefaultEntityView implements EntityView {
-  @NonNull private final EventReceiver receiver;
-  @NonNull private final Map<Entity.Key<?>, StateValue> entities;
-  @NonNull private final EntityViewUpdater updater;
+  @NonNull
+  private final EventReceiver receiver;
+  @NonNull
+  private final Map<Entity.Key<?>, StateValue> entities;
+  @NonNull
+  private final EntityViewUpdater updater;
 
   DefaultEntityView(EventReceiver receiver, Map<Entity.Key<?>, StateValue> entities) {
-    this(receiver, entities, new EntityViewUpdater(entities));
+    this(receiver, entities, new DefaultEntityViewUpdater(entities));
   }
 
   public DefaultEntityView(EventReceiver receiver) {
@@ -74,8 +76,8 @@ public class DefaultEntityView implements EntityView {
       .filter(it -> it.getValue().deleted)
       .filter(it -> it.getKey().getClass().equals(keyClass))
       .collect(Collectors.toMap(
-        entry -> (K)entry.getKey(),
-        entry -> Optional.ofNullable((Entity<K, S>)entry.getValue().entity))
+        entry -> (K) entry.getKey(),
+        entry -> Optional.ofNullable((Entity<K, S>) entry.getValue().entity))
       );
   }
 

--- a/state/core/src/main/java/com/expediagroup/streamplatform/streamregistry/state/DefaultEntityViewUpdater.java
+++ b/state/core/src/main/java/com/expediagroup/streamplatform/streamregistry/state/DefaultEntityViewUpdater.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) 2018-2022 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.streamplatform.streamregistry.state;
+
+import com.expediagroup.streamplatform.streamregistry.state.model.Entity;
+import com.expediagroup.streamplatform.streamregistry.state.model.event.Event;
+import com.expediagroup.streamplatform.streamregistry.state.model.event.SpecificationDeletionEvent;
+import com.expediagroup.streamplatform.streamregistry.state.model.event.SpecificationEvent;
+import com.expediagroup.streamplatform.streamregistry.state.model.event.StatusDeletionEvent;
+import com.expediagroup.streamplatform.streamregistry.state.model.event.StatusEvent;
+import com.expediagroup.streamplatform.streamregistry.state.model.specification.Specification;
+import com.expediagroup.streamplatform.streamregistry.state.model.status.DefaultStatus;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.expediagroup.streamplatform.streamregistry.state.StateValue.deleted;
+import static com.expediagroup.streamplatform.streamregistry.state.StateValue.existing;
+
+@Slf4j
+@RequiredArgsConstructor
+class DefaultEntityViewUpdater implements EntityViewUpdater {
+  @NonNull
+  private final Map<Entity.Key<?>, StateValue> entities;
+
+  @Override
+  public <K extends Entity.Key<S>, S extends Specification> Entity<K, S> update(Event<K, S> event) {
+    if (event instanceof SpecificationEvent) {
+      return update((SpecificationEvent<K, S>) event);
+    } else if (event instanceof StatusEvent) {
+      return update((StatusEvent<K, S>) event);
+    } else if (event instanceof SpecificationDeletionEvent) {
+      return delete((SpecificationDeletionEvent<K, S>) event);
+    } else if (event instanceof StatusDeletionEvent) {
+      return delete((StatusDeletionEvent<K, S>) event);
+    } else {
+      throw new IllegalArgumentException("Unknown event " + event);
+    }
+  }
+
+  public <K extends Entity.Key<S>, S extends Specification> Optional<Entity<K, S>> purge(K key) {
+    val stateEntity = Optional.ofNullable(entities.get(key))
+      .filter(it -> it.deleted);
+    stateEntity.ifPresent(it -> {
+      entities.remove(key);
+      log.debug("Purged entity for key={}", key);
+    });
+    return stateEntity.map(it -> (Entity<K, S>) it.entity);
+  }
+
+  private <K extends Entity.Key<S>, S extends Specification> Entity<K, S> update(SpecificationEvent<K, S> event) {
+    val oldEntity = (Entity<K, S>) getExistingEntity(event.getKey());
+    val status = Optional.ofNullable(oldEntity)
+      .map(Entity::getStatus)
+      .orElseGet(DefaultStatus::new);
+    val entity = new Entity<>(event.getKey(), event.getSpecification(), status);
+    entities.put(event.getKey(), existing(entity));
+    log.debug("Updated {} with {}", event.getKey(), event.getSpecification());
+    return oldEntity;
+  }
+
+  private <K extends Entity.Key<S>, S extends Specification> Entity<K, S> update(StatusEvent<K, S> event) {
+    val oldEntity = (Entity<K, S>) getExistingEntity(event.getKey());
+    if (oldEntity == null) {
+      log.warn("Received status {} non existent entity {}", event.getStatusEntry().getName(), event.getKey());
+      return null;
+    }
+    val entity = new Entity<>(event.getKey(), oldEntity.getSpecification(), oldEntity.getStatus().with(event.getStatusEntry()));
+    entities.put(event.getKey(), existing(entity));
+    log.debug("Updated {} with {}", event.getKey(), event.getStatusEntry());
+    return oldEntity;
+  }
+
+  private <K extends Entity.Key<S>, S extends Specification> Entity<K, S> delete(SpecificationDeletionEvent<K, S> event) {
+    val oldEntity = (Entity<K, S>) getExistingEntity(event.getKey());
+    entities.put(event.getKey(), deleted(oldEntity));
+    log.debug("Deleted entity for {}", event.getKey());
+    return oldEntity;
+  }
+
+  private <K extends Entity.Key<S>, S extends Specification> Entity<K, S> delete(StatusDeletionEvent<K, S> event) {
+    val oldEntity = (Entity<K, S>) getExistingEntity(event.getKey());
+    if (oldEntity == null) {
+      log.warn("Received status deletion {} for non existent entity {}", event.getStatusName(), event.getKey());
+      return null;
+    }
+    val entity = oldEntity.withStatus(oldEntity.getStatus().without(event.getStatusName()));
+    entities.put(event.getKey(), existing(entity));
+    log.debug("Deleted status {} for {}", event.getStatusName(), event.getKey());
+    return oldEntity;
+  }
+
+  private Entity<?, ?> getExistingEntity(Entity.Key<?> key) {
+    return Optional.ofNullable(entities.get(key))
+      .filter(it -> !it.deleted)
+      .map(it -> it.entity)
+      .orElse(null);
+  }
+}

--- a/state/core/src/main/java/com/expediagroup/streamplatform/streamregistry/state/EntityViewUpdater.java
+++ b/state/core/src/main/java/com/expediagroup/streamplatform/streamregistry/state/EntityViewUpdater.java
@@ -15,102 +15,15 @@
  */
 package com.expediagroup.streamplatform.streamregistry.state;
 
-import static com.expediagroup.streamplatform.streamregistry.state.StateValue.deleted;
-import static com.expediagroup.streamplatform.streamregistry.state.StateValue.existing;
-
-import java.util.Map;
-import java.util.Optional;
-
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
-
 import com.expediagroup.streamplatform.streamregistry.state.model.Entity;
 import com.expediagroup.streamplatform.streamregistry.state.model.event.Event;
-import com.expediagroup.streamplatform.streamregistry.state.model.event.SpecificationDeletionEvent;
-import com.expediagroup.streamplatform.streamregistry.state.model.event.SpecificationEvent;
-import com.expediagroup.streamplatform.streamregistry.state.model.event.StatusDeletionEvent;
-import com.expediagroup.streamplatform.streamregistry.state.model.event.StatusEvent;
 import com.expediagroup.streamplatform.streamregistry.state.model.specification.Specification;
-import com.expediagroup.streamplatform.streamregistry.state.model.status.DefaultStatus;
 
-@Slf4j
-@RequiredArgsConstructor
-class EntityViewUpdater {
-  @NonNull
-  private final Map<Entity.Key<?>, StateValue> entities;
+import java.util.Optional;
 
-  <K extends Entity.Key<S>, S extends Specification> Entity<K, S> update(Event<K, S> event) {
-    if (event instanceof SpecificationEvent) {
-      return update((SpecificationEvent<K, S>) event);
-    } else if (event instanceof StatusEvent) {
-      return update((StatusEvent<K, S>) event);
-    } else if (event instanceof SpecificationDeletionEvent) {
-      return delete((SpecificationDeletionEvent<K, S>) event);
-    } else if (event instanceof StatusDeletionEvent) {
-      return delete((StatusDeletionEvent<K, S>) event);
-    } else {
-      throw new IllegalArgumentException("Unknown event " + event);
-    }
-  }
+interface EntityViewUpdater {
 
-  <K extends Entity.Key<S>, S extends Specification> Optional<Entity<K, S>> purge(K key) {
-    val stateEntity = Optional.ofNullable(entities.get(key))
-      .filter(it -> it.deleted);
-    stateEntity.ifPresent(it -> {
-      entities.remove(key);
-      log.debug("Purged entity for key={}", key);
-    });
-    return stateEntity.map(it -> (Entity<K, S>) it.entity);
-  }
+  <K extends Entity.Key<S>, S extends Specification> Optional<Entity<K, S>> purge(K key);
 
-  private <K extends Entity.Key<S>, S extends Specification> Entity<K, S> update(SpecificationEvent<K, S> event) {
-    val oldEntity = (Entity<K, S>) getExistingEntity(event.getKey());
-    val status = Optional.ofNullable(oldEntity)
-      .map(Entity::getStatus)
-      .orElseGet(DefaultStatus::new);
-    val entity = new Entity<>(event.getKey(), event.getSpecification(), status);
-    entities.put(event.getKey(), existing(entity));
-    log.debug("Updated {} with {}", event.getKey(), event.getSpecification());
-    return oldEntity;
-  }
-
-  private <K extends Entity.Key<S>, S extends Specification> Entity<K, S> update(StatusEvent<K, S> event) {
-    val oldEntity = (Entity<K, S>) getExistingEntity(event.getKey());
-    if (oldEntity == null) {
-      log.warn("Received status {} non existent entity {}", event.getStatusEntry().getName(), event.getKey());
-      return null;
-    }
-    val entity = new Entity<>(event.getKey(), oldEntity.getSpecification(), oldEntity.getStatus().with(event.getStatusEntry()));
-    entities.put(event.getKey(), existing(entity));
-    log.debug("Updated {} with {}", event.getKey(), event.getStatusEntry());
-    return oldEntity;
-  }
-
-  private <K extends Entity.Key<S>, S extends Specification> Entity<K, S> delete(SpecificationDeletionEvent<K, S> event) {
-    val oldEntity = (Entity<K, S>) getExistingEntity(event.getKey());
-    entities.put(event.getKey(), deleted(oldEntity));
-    log.debug("Deleted entity for {}", event.getKey());
-    return oldEntity;
-  }
-
-  private <K extends Entity.Key<S>, S extends Specification> Entity<K, S> delete(StatusDeletionEvent<K, S> event) {
-    val oldEntity = (Entity<K, S>) getExistingEntity(event.getKey());
-    if (oldEntity == null) {
-      log.warn("Received status deletion {} for non existent entity {}", event.getStatusName(), event.getKey());
-      return null;
-    }
-    val entity = oldEntity.withStatus(oldEntity.getStatus().without(event.getStatusName()));
-    entities.put(event.getKey(), existing(entity));
-    log.debug("Deleted status {} for {}", event.getStatusName(), event.getKey());
-    return oldEntity;
-  }
-
-  private Entity<?, ?> getExistingEntity(Entity.Key<?> key) {
-    return Optional.ofNullable(entities.get(key))
-      .filter(it -> !it.deleted)
-      .map(it -> it.entity)
-      .orElse(null);
-  }
+  <K extends Entity.Key<S>, S extends Specification> Entity<K, S> update(Event<K, S> event);
 }

--- a/state/core/src/main/java/com/expediagroup/streamplatform/streamregistry/state/EntityViews.java
+++ b/state/core/src/main/java/com/expediagroup/streamplatform/streamregistry/state/EntityViews.java
@@ -52,14 +52,22 @@ public final class EntityViews {
 
     @Override
     public <K extends Entity.Key<S>, S extends Specification> Entity<K, S> update(Event<K, S> event) {
-      meterRegistry.counter("stream_registry_state.receiver.update", event.getClass().getSimpleName().toLowerCase()).increment();
+      meterRegistry.counter("stream_registry_state.receiver.update", Tags.of("type", simpleName(event))).increment();
       return delegate.update(event);
     }
 
     @Override
     public <K extends Entity.Key<S>, S extends Specification> Optional<Entity<K, S>> purge(K key) {
-      meterRegistry.counter("stream_registry_state.receiver.purge", key.getClass().getSimpleName().toLowerCase()).increment();
+      meterRegistry.counter("stream_registry_state.receiver.purge", Tags.of("type", simpleName(key))).increment();
       return delegate.purge(key);
+    }
+
+    private static String simpleName(Object obj) {
+      if (obj == null) {
+        return "null";
+      } else {
+        return obj.getClass().getSimpleName().toLowerCase();
+      }
     }
   }
 }

--- a/state/core/src/main/java/com/expediagroup/streamplatform/streamregistry/state/EntityViews.java
+++ b/state/core/src/main/java/com/expediagroup/streamplatform/streamregistry/state/EntityViews.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2018-2022 Expedia, Inc.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/state/core/src/main/java/com/expediagroup/streamplatform/streamregistry/state/EntityViews.java
+++ b/state/core/src/main/java/com/expediagroup/streamplatform/streamregistry/state/EntityViews.java
@@ -47,12 +47,14 @@ public final class EntityViews {
 
   @RequiredArgsConstructor(access = PACKAGE)
   static final class MeteredEntityViewUpdater implements EntityViewUpdater {
+    @NonNull
     private final EntityViewUpdater delegate;
+    @NonNull
     private final MeterRegistry meterRegistry;
 
     @Override
     public <K extends Entity.Key<S>, S extends Specification> Entity<K, S> update(Event<K, S> event) {
-      meterRegistry.counter("stream_registry_state.receiver.update", Tags.of("type", simpleName(event))).increment();
+      meterRegistry.counter("stream_registry_state.receiver.update", Tags.of("event", simpleName(event))).increment();
       return delegate.update(event);
     }
 

--- a/state/core/src/main/java/com/expediagroup/streamplatform/streamregistry/state/EntityViews.java
+++ b/state/core/src/main/java/com/expediagroup/streamplatform/streamregistry/state/EntityViews.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2018-2022 Expedia, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.streamplatform.streamregistry.state;
+
+import com.expediagroup.streamplatform.streamregistry.state.model.Entity;
+import com.expediagroup.streamplatform.streamregistry.state.model.event.Event;
+import com.expediagroup.streamplatform.streamregistry.state.model.specification.Specification;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static lombok.AccessLevel.PACKAGE;
+
+public final class EntityViews {
+
+  @NonNull
+  public static EntityView defaultEntityView(EventReceiver receiver) {
+    return new DefaultEntityView(receiver);
+  }
+
+  @NonNull
+  public static EntityView meteredEntityView(EventReceiver receiver, MeterRegistry meterRegistry) {
+    Map<Entity.Key<?>, StateValue> entities = new ConcurrentHashMap<>();
+    meterRegistry.gaugeMapSize("stream_registry_state.view.entities", Tags.empty(), entities);
+
+    DefaultEntityViewUpdater defaultEntityViewUpdater = new DefaultEntityViewUpdater(entities);
+    return new DefaultEntityView(receiver, entities, new MeteredEntityViewUpdater(defaultEntityViewUpdater, meterRegistry));
+  }
+
+  @RequiredArgsConstructor(access = PACKAGE)
+  static final class MeteredEntityViewUpdater implements EntityViewUpdater {
+    private final EntityViewUpdater delegate;
+    private final MeterRegistry meterRegistry;
+
+    @Override
+    public <K extends Entity.Key<S>, S extends Specification> Entity<K, S> update(Event<K, S> event) {
+      meterRegistry.counter("stream_registry_state.receiver.update", event.getClass().getSimpleName().toLowerCase()).increment();
+      return delegate.update(event);
+    }
+
+    @Override
+    public <K extends Entity.Key<S>, S extends Specification> Optional<Entity<K, S>> purge(K key) {
+      meterRegistry.counter("stream_registry_state.receiver.purge", key.getClass().getSimpleName().toLowerCase()).increment();
+      return delegate.purge(key);
+    }
+  }
+}

--- a/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/DefaultEntityViewUpdaterTest.java
+++ b/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/DefaultEntityViewUpdaterTest.java
@@ -1,0 +1,12 @@
+package com.expediagroup.streamplatform.streamregistry.state;
+
+import com.expediagroup.streamplatform.streamregistry.state.model.Entity;
+
+import java.util.Map;
+
+public class DefaultEntityViewUpdaterTest extends EntityViewUpdaterTest {
+  @Override
+  public EntityViewUpdater entityViewUpdater(Map<Entity.Key<?>, StateValue> entities) {
+    return new DefaultEntityViewUpdater(entities);
+  }
+}

--- a/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/EntityViewUpdaterTest.java
+++ b/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/EntityViewUpdaterTest.java
@@ -49,13 +49,14 @@ public abstract class EntityViewUpdaterTest {
 
   private final Map<Entity.Key<?>, StateValue> entities = new HashMap<>();
 
-  private final EntityViewUpdater underTest = entityViewUpdater(entities);
-
   private final DefaultSpecification oldSpecification = specification.withDescription("old-description");
   private final DefaultStatus oldStatus = new DefaultStatus();
   private final Entity<DomainKey, DefaultSpecification> oldEntity = entity
     .withSpecification(oldSpecification)
     .withStatus(oldStatus);
+
+
+  final EntityViewUpdater underTest = entityViewUpdater(entities);
 
 
   public abstract EntityViewUpdater entityViewUpdater(Map<Entity.Key<?>, StateValue> entities);

--- a/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/EntityViewUpdaterTest.java
+++ b/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/EntityViewUpdaterTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2018-2021 Expedia, Inc.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/EntityViewUpdaterTest.java
+++ b/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/EntityViewUpdaterTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2018-2021 Expedia, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,6 +14,19 @@
  * limitations under the License.
  */
 package com.expediagroup.streamplatform.streamregistry.state;
+
+import com.expediagroup.streamplatform.streamregistry.state.model.Entity;
+import com.expediagroup.streamplatform.streamregistry.state.model.Entity.DomainKey;
+import com.expediagroup.streamplatform.streamregistry.state.model.event.Event;
+import com.expediagroup.streamplatform.streamregistry.state.model.specification.DefaultSpecification;
+import com.expediagroup.streamplatform.streamregistry.state.model.status.DefaultStatus;
+import lombok.val;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 import static com.expediagroup.streamplatform.streamregistry.state.SampleEntities.entity;
 import static com.expediagroup.streamplatform.streamregistry.state.SampleEntities.key;
@@ -32,32 +45,20 @@ import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 import static org.junit.Assert.assertThat;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-
-import lombok.val;
-
-import org.junit.After;
-import org.junit.Test;
-
-import com.expediagroup.streamplatform.streamregistry.state.model.Entity;
-import com.expediagroup.streamplatform.streamregistry.state.model.Entity.DomainKey;
-import com.expediagroup.streamplatform.streamregistry.state.model.event.Event;
-import com.expediagroup.streamplatform.streamregistry.state.model.specification.DefaultSpecification;
-import com.expediagroup.streamplatform.streamregistry.state.model.status.DefaultStatus;
-
-public class EntityViewUpdaterTest {
+public abstract class EntityViewUpdaterTest {
 
   private final Map<Entity.Key<?>, StateValue> entities = new HashMap<>();
 
-  private final EntityViewUpdater underTest = new EntityViewUpdater(entities);
+  private final EntityViewUpdater underTest = entityViewUpdater(entities);
 
   private final DefaultSpecification oldSpecification = specification.withDescription("old-description");
   private final DefaultStatus oldStatus = new DefaultStatus();
   private final Entity<DomainKey, DefaultSpecification> oldEntity = entity
     .withSpecification(oldSpecification)
     .withStatus(oldStatus);
+
+
+  public abstract EntityViewUpdater entityViewUpdater(Map<Entity.Key<?>, StateValue> entities);
 
   @After
   public void clean() {

--- a/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/MeteredEntityViewUpdaterTest.java
+++ b/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/MeteredEntityViewUpdaterTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2018-2022 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.expediagroup.streamplatform.streamregistry.state;
 
 import com.expediagroup.streamplatform.streamregistry.state.model.Entity;

--- a/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/MeteredEntityViewUpdaterTest.java
+++ b/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/MeteredEntityViewUpdaterTest.java
@@ -3,15 +3,38 @@ package com.expediagroup.streamplatform.streamregistry.state;
 import com.expediagroup.streamplatform.streamregistry.state.model.Entity;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.After;
+import org.junit.Test;
 
 import java.util.Map;
 
+import static com.expediagroup.streamplatform.streamregistry.state.SampleEntities.specificationEvent;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 public class MeteredEntityViewUpdaterTest extends EntityViewUpdaterTest {
 
-  private MeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private static final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+  @After
+  public void cleanMeterRegistry() {
+    meterRegistry.clear();
+  }
 
   @Override
   public EntityViewUpdater entityViewUpdater(Map<Entity.Key<?>, StateValue> entities) {
     return new EntityViews.MeteredEntityViewUpdater(new DefaultEntityViewUpdater(entities), meterRegistry);
+  }
+
+  @Test
+  public void updatesAreRecorded() {
+    underTest.update(specificationEvent);
+    assertThat(meterRegistry.counter("stream_registry_state.receiver.update", "event", "specificationevent").count(), is(1.0D));
+  }
+
+  @Test
+  public void purgesAreRecorded() {
+    underTest.purge(specificationEvent.getKey());
+    assertThat(meterRegistry.counter("stream_registry_state.receiver.purge", "type", "domainkey").count(), is(1.0D));
   }
 }

--- a/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/MeteredEntityViewUpdaterTest.java
+++ b/state/core/src/test/java/com/expediagroup/streamplatform/streamregistry/state/MeteredEntityViewUpdaterTest.java
@@ -1,0 +1,17 @@
+package com.expediagroup.streamplatform.streamregistry.state;
+
+import com.expediagroup.streamplatform.streamregistry.state.model.Entity;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import java.util.Map;
+
+public class MeteredEntityViewUpdaterTest extends EntityViewUpdaterTest {
+
+  private MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+  @Override
+  public EntityViewUpdater entityViewUpdater(Map<Entity.Key<?>, StateValue> entities) {
+    return new EntityViews.MeteredEntityViewUpdater(new DefaultEntityViewUpdater(entities), meterRegistry);
+  }
+}

--- a/state/example/src/main/java/com/expediagroup/streamplatform/streamregistry/state/example/ExampleAgentApp.java
+++ b/state/example/src/main/java/com/expediagroup/streamplatform/streamregistry/state/example/ExampleAgentApp.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2018-2020 Expedia, Inc.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/state/example/src/main/java/com/expediagroup/streamplatform/streamregistry/state/example/ExampleAgentApp.java
+++ b/state/example/src/main/java/com/expediagroup/streamplatform/streamregistry/state/example/ExampleAgentApp.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2018-2020 Expedia, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,20 +16,18 @@
 package com.expediagroup.streamplatform.streamregistry.state.example;
 
 import com.apollographql.apollo.ApolloClient;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-
-import com.expediagroup.streamplatform.streamregistry.state.DefaultEntityView;
 import com.expediagroup.streamplatform.streamregistry.state.EntityView;
+import com.expediagroup.streamplatform.streamregistry.state.EntityViews;
 import com.expediagroup.streamplatform.streamregistry.state.EventReceiver;
 import com.expediagroup.streamplatform.streamregistry.state.EventSender;
 import com.expediagroup.streamplatform.streamregistry.state.graphql.Credentials;
 import com.expediagroup.streamplatform.streamregistry.state.graphql.DefaultApolloClientFactory;
 import com.expediagroup.streamplatform.streamregistry.state.graphql.GraphQLEventSender;
 import com.expediagroup.streamplatform.streamregistry.state.kafka.KafkaEventReceiver;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class ExampleAgentApp {
@@ -39,9 +37,9 @@ public class ExampleAgentApp {
 
   @Bean
   ApolloClient apolloClient(
-      @Value("${streamRegistryUrl}") String streamRegistryUrl,
-      @Value("${streamRegistryUsername}") String streamRegistryUsername,
-      @Value("${streamRegistryPassword}") String streamRegistryPassword
+    @Value("${streamRegistryUrl}") String streamRegistryUrl,
+    @Value("${streamRegistryUsername}") String streamRegistryUsername,
+    @Value("${streamRegistryPassword}") String streamRegistryPassword
   ) {
     return new DefaultApolloClientFactory(streamRegistryUrl, new Credentials(streamRegistryUsername, streamRegistryPassword)).create();
   }
@@ -53,22 +51,22 @@ public class ExampleAgentApp {
 
   @Bean
   EventReceiver eventReceiver(
-      @Value("${bootstrapServers}") String bootstrapServers,
-      @Value("${topic}") String topic,
-      @Value("${groupId}") String groupId,
-      @Value("${schemaRegistryUrl}") String schemaRegistryUrl
+    @Value("${bootstrapServers}") String bootstrapServers,
+    @Value("${topic}") String topic,
+    @Value("${groupId}") String groupId,
+    @Value("${schemaRegistryUrl}") String schemaRegistryUrl
   ) {
     KafkaEventReceiver.Config receiverConfig = KafkaEventReceiver.Config.builder()
-        .bootstrapServers(bootstrapServers)
-        .topic(topic)
-        .groupId(groupId)
-        .schemaRegistryUrl(schemaRegistryUrl)
-        .build();
+      .bootstrapServers(bootstrapServers)
+      .topic(topic)
+      .groupId(groupId)
+      .schemaRegistryUrl(schemaRegistryUrl)
+      .build();
     return new KafkaEventReceiver(receiverConfig);
   }
 
   @Bean
   EntityView entityView(EventReceiver eventReceiver) {
-    return new DefaultEntityView(eventReceiver);
+    return EntityViews.defaultEntityView(eventReceiver);
   }
 }

--- a/state/it/src/test/java/com/expediagroup/streamplatform/streamregistry/state/it/AgentIT.java
+++ b/state/it/src/test/java/com/expediagroup/streamplatform/streamregistry/state/it/AgentIT.java
@@ -15,6 +15,40 @@
  */
 package com.expediagroup.streamplatform.streamregistry.state.it;
 
+import com.expediagroup.streamplatform.streamregistry.state.AgentData;
+import com.expediagroup.streamplatform.streamregistry.state.EntityView;
+import com.expediagroup.streamplatform.streamregistry.state.EntityViewListener;
+import com.expediagroup.streamplatform.streamregistry.state.EntityViews;
+import com.expediagroup.streamplatform.streamregistry.state.EventSender;
+import com.expediagroup.streamplatform.streamregistry.state.kafka.KafkaEventReceiver;
+import com.expediagroup.streamplatform.streamregistry.state.kafka.KafkaEventSender;
+import com.expediagroup.streamplatform.streamregistry.state.model.Entity;
+import com.expediagroup.streamplatform.streamregistry.state.model.Entity.DomainKey;
+import com.expediagroup.streamplatform.streamregistry.state.model.Entity.Key;
+import com.expediagroup.streamplatform.streamregistry.state.model.event.Event;
+import com.expediagroup.streamplatform.streamregistry.state.model.specification.DefaultSpecification;
+import com.expediagroup.streamplatform.streamregistry.state.model.specification.Specification;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import lombok.val;
+import org.apache.commons.lang3.tuple.Pair;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.KafkaContainer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
 import static com.expediagroup.streamplatform.streamregistry.state.AgentData.generateData;
 import static com.expediagroup.streamplatform.streamregistry.state.model.event.Event.specificationDeletion;
 import static java.util.UUID.randomUUID;
@@ -29,41 +63,9 @@ import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.core.IsIterableContaining.hasItem;
 import static org.hamcrest.core.IsIterableContaining.hasItems;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.SneakyThrows;
-import lombok.val;
-
-import org.apache.commons.lang3.tuple.Pair;
-import org.awaitility.Awaitility;
-import org.awaitility.core.ConditionFactory;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.testcontainers.containers.KafkaContainer;
-
-import com.expediagroup.streamplatform.streamregistry.state.AgentData;
-import com.expediagroup.streamplatform.streamregistry.state.DefaultEntityView;
-import com.expediagroup.streamplatform.streamregistry.state.EntityView;
-import com.expediagroup.streamplatform.streamregistry.state.EntityViewListener;
-import com.expediagroup.streamplatform.streamregistry.state.EventSender;
-import com.expediagroup.streamplatform.streamregistry.state.kafka.KafkaEventReceiver;
-import com.expediagroup.streamplatform.streamregistry.state.kafka.KafkaEventSender;
-import com.expediagroup.streamplatform.streamregistry.state.model.Entity;
-import com.expediagroup.streamplatform.streamregistry.state.model.Entity.DomainKey;
-import com.expediagroup.streamplatform.streamregistry.state.model.Entity.Key;
-import com.expediagroup.streamplatform.streamregistry.state.model.event.Event;
-import com.expediagroup.streamplatform.streamregistry.state.model.specification.DefaultSpecification;
-import com.expediagroup.streamplatform.streamregistry.state.model.specification.Specification;
-
 public class AgentIT {
+
+  private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   private final String schemaRegistryUrl = "mock://schemas";
 
@@ -76,7 +78,7 @@ public class AgentIT {
 
   private String topicName;
   private KafkaEventSender kafkaEventSender;
-  private DefaultEntityView entityView;
+  private EntityView entityView;
   private StoringEntityViewListener dummyAgent;
   private AgentData data;
 
@@ -84,7 +86,7 @@ public class AgentIT {
   public void setUp() {
     topicName = topicName();
     kafkaEventSender = kafkaEventSender(topicName);
-    entityView = new DefaultEntityView(kafkaEventReceiver(topicName, "groupId"));
+    entityView = EntityViews.meteredEntityView(kafkaEventReceiver(topicName, "groupId"), meterRegistry);
     dummyAgent = new StoringEntityViewListener();
     data = generateData();
   }
@@ -205,7 +207,7 @@ public class AgentIT {
     assertThat(deletedDomainEvents(entityView), is(aMapWithSize(0)));
 
     // simulate the restart of an Agent
-    val restartedEntityView = new DefaultEntityView(kafkaEventReceiver(topicName, "groupId"));
+    val restartedEntityView = EntityViews.meteredEntityView(kafkaEventReceiver(topicName, "groupId"), meterRegistry);
     val restartedAgent = new StoringEntityViewListener();
     startAgent(restartedEntityView, restartedAgent);
 

--- a/state/it/src/test/java/com/expediagroup/streamplatform/streamregistry/state/it/StateIT.java
+++ b/state/it/src/test/java/com/expediagroup/streamplatform/streamregistry/state/it/StateIT.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import com.expediagroup.streamplatform.streamregistry.state.EntityViews;
 import lombok.val;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -89,7 +90,7 @@ public class StateIT {
         .topic(topic)
         .build(), correlator);
 
-    EntityView view = new DefaultEntityView(receiver);
+    EntityView view = EntityViews.defaultEntityView(receiver);
     val listener = mock(EntityViewListener.class);
     view.load(listener).join();
 


### PR DESCRIPTION
# stream-registry PR

This PR introduces the ability to add basic metrics to `EntityView`. This is a backwards compatible change.

### Added
* `EntityViews::defaultEntityView` can be used to create `EntityView` that works exactly the same as before.
* `EntityView::meteredEntityView` can be used to create an `EntityView` that exposes minimal metrics.

### Changed
* `EntityViewUpdater` is now an interface with two implementations. This was never exposed outside of it's package so is backwards compatible.


# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
