### PR TITLE
Client configurator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.2.0]
-### Changed
+### Added
 - Support for configuring the KafkaProducer and KafkaConsumer that is used in KafkaEventSender and KafkaEventReceiver
   for example to attach KafkaClientMetrics.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.0]
+### Changed
+- Support for configuring the KafkaProducer and KafkaConsumer that is used in KafkaEventSender and KafkaEventReceiver
+  for example to attach KafkaClientMetrics.
+
 ## [1.1.4]
 ### Changed
 - Use Kotlin 1.7.10

--- a/state/api/src/main/java/com/expediagroup/streamplatform/streamregistry/state/Configurator.java
+++ b/state/api/src/main/java/com/expediagroup/streamplatform/streamregistry/state/Configurator.java
@@ -1,0 +1,9 @@
+package com.expediagroup.streamplatform.streamregistry.state;
+
+/**
+ * Allows clients to be configured, for example to attach metrics to a client.
+ * @param <T> The client type to be configured.
+ */
+public interface Configurator<T> {
+  void configure(T client);
+}

--- a/state/it/src/test/java/com/expediagroup/streamplatform/streamregistry/state/it/StateIT.java
+++ b/state/it/src/test/java/com/expediagroup/streamplatform/streamregistry/state/it/StateIT.java
@@ -82,13 +82,13 @@ public class StateIT {
         .schemaRegistryUrl(schemaRegistryUrl)
         .topic(topic)
         .groupId("groupId")
-        .build(), correlator, kafkaConsumer -> {});
+        .build(), correlator);
 
     val kafkaSender = new KafkaEventSender(KafkaEventSender.Config.builder()
         .bootstrapServers(kafka.getBootstrapServers())
         .schemaRegistryUrl(schemaRegistryUrl)
         .topic(topic)
-        .build(), correlator, kafkaProducer -> {});
+        .build(), correlator);
 
     EntityView view = EntityViews.defaultEntityView(receiver);
     val listener = mock(EntityViewListener.class);

--- a/state/it/src/test/java/com/expediagroup/streamplatform/streamregistry/state/it/StateIT.java
+++ b/state/it/src/test/java/com/expediagroup/streamplatform/streamregistry/state/it/StateIT.java
@@ -82,13 +82,13 @@ public class StateIT {
         .schemaRegistryUrl(schemaRegistryUrl)
         .topic(topic)
         .groupId("groupId")
-        .build(), correlator);
+        .build(), correlator, kafkaConsumer -> {});
 
     val kafkaSender = new KafkaEventSender(KafkaEventSender.Config.builder()
         .bootstrapServers(kafka.getBootstrapServers())
         .schemaRegistryUrl(schemaRegistryUrl)
         .topic(topic)
-        .build(), correlator);
+        .build(), correlator, kafkaProducer -> {});
 
     EntityView view = EntityViews.defaultEntityView(receiver);
     val listener = mock(EntityViewListener.class);


### PR DESCRIPTION
# stream-registry PR

_&lt;High level description of the PR&gt;_

### Added
* Support for configuring the KafkaProducer and KafkaConsumer that is used in KafkaEventSender and KafkaEventReceiver for example to attach KafkaClientMetrics.

# PR Checklist Forms

- [x] CHANGELOG.md updated
- [x] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
