### PR TITLE
STREAMP-8192-adding-process-in-processBinding-query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Updated
+- Adding process in ProcessBinding Query.
+
 ## [1.3.0]
 ### Changed
 - Fixing some property names related to zone keys 

--- a/graphql/api/src/main/resources/stream-registry.graphql
+++ b/graphql/api/src/main/resources/stream-registry.graphql
@@ -360,6 +360,7 @@ type ProcessBinding {
     zoneKey: ZoneKey!
     specification: Specification!
     status: Status
+    process: Process!
     inputs: [ProcessInputStreamBinding!]!
     outputs: [ProcessOutputStreamBinding!]!
 }

--- a/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/ProcessBindingTestStage.java
+++ b/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/ProcessBindingTestStage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2021 Expedia, Inc.
+ * Copyright (C) 2018-2023 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,10 +125,16 @@ public class ProcessBindingTestStage extends AbstractTestStage {
     Response r = client.invoke(factory.upsertProcessBindingMutationBuilder().build());
 
     ProcessBindingsQuery.Data after = (ProcessBindingsQuery.Data) client.getOptionalData(ProcessBindingsQuery.builder().key(query).build()).get();
-
     assertNotNull(after.getProcessBinding().getByQuery().get(0)
         .getFragments().getProcessBindingPart().getStatus().get()
         .getFragments().getStatusPart().getAgentStatus());
+    assertNotNull(after.getProcessBinding().getByQuery().get(0)
+      .getFragments().getProcessBindingPart().getProcess()
+      .getFragments().getProcessPart()
+    );
+    System.out.println(after.getProcessBinding().getByQuery().get(0)
+      .getFragments().getProcessBindingPart().getProcess()
+      .getFragments().getProcessPart().getSpecification().getFragments().getSpecificationPart().getConfiguration());
   }
 
   @Override

--- a/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/ProcessBindingTestStage.java
+++ b/it/src/test/java/com/expediagroup/streamplatform/streamregistry/it/ProcessBindingTestStage.java
@@ -111,6 +111,11 @@ public class ProcessBindingTestStage extends AbstractTestStage {
     ProcessBindingQuery.Data after = (ProcessBindingQuery.Data) client.getOptionalData(ProcessBindingQuery.builder().key(input).build()).get();
 
     assertEquals(after.getProcessBinding().getByKey().get().getFragments().getProcessBindingPart().getKey().getProcessName(), input.processName());
+    assertNotNull(
+      after.getProcessBinding().getByKey().get()
+        .getFragments().getProcessBindingPart().getProcess()
+        .getFragments().getProcessPart()
+    );
   }
 
   @Override
@@ -132,9 +137,6 @@ public class ProcessBindingTestStage extends AbstractTestStage {
       .getFragments().getProcessBindingPart().getProcess()
       .getFragments().getProcessPart()
     );
-    System.out.println(after.getProcessBinding().getByQuery().get(0)
-      .getFragments().getProcessBindingPart().getProcess()
-      .getFragments().getProcessPart().getSpecification().getFragments().getSpecificationPart().getConfiguration());
   }
 
   @Override

--- a/it/src/test/resources/client.graphql
+++ b/it/src/test/resources/client.graphql
@@ -261,6 +261,10 @@ fragment ProcessBindingPart on ProcessBinding{
     __typename
     ...StatusPart
   }
+  process{
+    __typename
+    ...ProcessPart
+  }
 }
 
 mutation InsertProcessBinding(


### PR DESCRIPTION
# stream-registry PR

_&lt;Adding process in processBinding fetch query&gt;_

### Added
* _&lt; Earlier we couldn't fetch process using processBinding Query &gt;_
* _&lt; Now we can actually fetch process and processbinding using single query &gt;_



# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
