### PR TITLE
fix: STREAMP-9751: ensure deletes are processed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+### Bugfix
+- Ensure that deletes are handled correctly in `DefaultRepository` before returning control to the caller.
+
 ### Changed
 - Reduced Logging level for status events.
 

--- a/repository/kafka/src/main/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/DefaultRepository.java
+++ b/repository/kafka/src/main/java/com/expediagroup/streamplatform/streamregistry/repository/kafka/DefaultRepository.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2021 Expedia, Inc.
+ * Copyright (C) 2018-2023 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,6 +107,6 @@ abstract class DefaultRepository<
       send(Event.statusDeletion(stateEntity.getKey(), e.getName()), futures);
     });
     send(Event.specificationDeletion(stateEntity.getKey()), futures);
+    futures.forEach(CompletableFuture::join);
   }
-
 }


### PR DESCRIPTION
# stream-registry PR

Ensure that deletes are actually processed. Don't just ignore the `CompletableFuture`.

### Changed
* `DefaultRepository::delete` will wait until deletes have actually been processed before returning control to the caller.


# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
