### PR TITLE
fix: Adding configurable property to handle double delete events correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+### Updated
+- Adding Configurable property to enable or disable checking if entity exists in EntityView during delete.
+
 ## [unreleased]
 ### Added
 - stream-registry bom

--- a/graphql/api/pom.xml
+++ b/graphql/api/pom.xml
@@ -74,6 +74,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/StateHelper.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/StateHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2023 Expedia, Inc.
+ * Copyright (C) 2018-2024 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,47 @@
  */
 package com.expediagroup.streamplatform.streamregistry.graphql;
 
+import java.util.Collections;
 import java.util.Optional;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.SchemaKeyInput;
+import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.SpecificationInput;
+import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.StatusInput;
+import com.expediagroup.streamplatform.streamregistry.model.Specification;
 import com.expediagroup.streamplatform.streamregistry.model.Stated;
+import com.expediagroup.streamplatform.streamregistry.model.Status;
+import com.expediagroup.streamplatform.streamregistry.model.keys.SchemaKey;
 
 public class StateHelper {
 
+  private static final ObjectMapper mapper = new ObjectMapper();
+
   public static void maintainState(Stated stated, Optional<? extends Stated> existing) {
     existing.ifPresent(value -> stated.setStatus(value.getStatus()));
+  }
+
+  public static Specification specification() {
+    return SpecificationInput.builder()
+      .description("description")
+      .tags(Collections.emptyList())
+      .type("default")
+      .configuration(mapper.createObjectNode())
+      .security(Collections.emptyList())
+      .build().asSpecification();
+  }
+
+  public static Status status() {
+    return StatusInput.builder()
+      .agentStatus(mapper.createObjectNode())
+      .build().asStatus();
+  }
+
+  public static SchemaKey schemaKey() {
+    return SchemaKeyInput.builder()
+      .domain("domain")
+      .name("name")
+      .build().asSchemaKey();
   }
 }

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ConsumerBindingMutationImpl.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ConsumerBindingMutationImpl.java
@@ -34,6 +34,7 @@ import com.expediagroup.streamplatform.streamregistry.model.ConsumerBinding;
 @Component
 @RequiredArgsConstructor
 public class ConsumerBindingMutationImpl implements ConsumerBindingMutation {
+
   private final ConsumerBindingService consumerBindingService;
   private final ConsumerBindingView consumerBindingView;
 
@@ -62,9 +63,9 @@ public class ConsumerBindingMutationImpl implements ConsumerBindingMutation {
 
   @Override
   public Boolean delete(ConsumerBindingKeyInput key) {
-    if(checkExistEnabled){
-    consumerBindingView.get(key.asConsumerBindingKey()).ifPresent(consumerBindingService::delete);
-    }else {
+    if (checkExistEnabled) {
+      consumerBindingView.get(key.asConsumerBindingKey()).ifPresent(consumerBindingService::delete);
+    } else {
       ConsumerBinding consumerBinding = new ConsumerBinding(key.asConsumerBindingKey(), StateHelper.specification(), StateHelper.status());
       consumerBindingService.delete(consumerBinding);
     }

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ConsumerBindingMutationImpl.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ConsumerBindingMutationImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2021 Expedia, Inc.
+ * Copyright (C) 2018-2024 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,12 @@ import static com.expediagroup.streamplatform.streamregistry.graphql.StateHelper
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.expediagroup.streamplatform.streamregistry.core.services.ConsumerBindingService;
 import com.expediagroup.streamplatform.streamregistry.core.views.ConsumerBindingView;
+import com.expediagroup.streamplatform.streamregistry.graphql.StateHelper;
 import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.ConsumerBindingKeyInput;
 import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.SpecificationInput;
 import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.StatusInput;
@@ -34,6 +36,9 @@ import com.expediagroup.streamplatform.streamregistry.model.ConsumerBinding;
 public class ConsumerBindingMutationImpl implements ConsumerBindingMutation {
   private final ConsumerBindingService consumerBindingService;
   private final ConsumerBindingView consumerBindingView;
+
+  @Value("${entityView.exist.check.enabled:true}")
+  private boolean checkExistEnabled;
 
   @Override
   public ConsumerBinding insert(ConsumerBindingKeyInput key, SpecificationInput specification) {
@@ -57,7 +62,12 @@ public class ConsumerBindingMutationImpl implements ConsumerBindingMutation {
 
   @Override
   public Boolean delete(ConsumerBindingKeyInput key) {
+    if(checkExistEnabled){
     consumerBindingView.get(key.asConsumerBindingKey()).ifPresent(consumerBindingService::delete);
+    }else {
+      ConsumerBinding consumerBinding = new ConsumerBinding(key.asConsumerBindingKey(), StateHelper.specification(), StateHelper.status());
+      consumerBindingService.delete(consumerBinding);
+    }
     return true;
   }
 

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ConsumerMutationImpl.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ConsumerMutationImpl.java
@@ -34,6 +34,7 @@ import com.expediagroup.streamplatform.streamregistry.model.Consumer;
 @Component
 @RequiredArgsConstructor
 public class ConsumerMutationImpl implements ConsumerMutation {
+
   private final ConsumerService consumerService;
   private final ConsumerView consumerView;
 
@@ -62,9 +63,9 @@ public class ConsumerMutationImpl implements ConsumerMutation {
 
   @Override
   public Boolean delete(ConsumerKeyInput key) {
-    if(checkExistEnabled) {
-    consumerView.get(key.asConsumerKey()).ifPresent(consumerService::delete);
-    }else {
+    if (checkExistEnabled) {
+      consumerView.get(key.asConsumerKey()).ifPresent(consumerService::delete);
+    } else {
       Consumer consumer = new Consumer(key.asConsumerKey(), StateHelper.specification(), StateHelper.status());
       consumerService.delete(consumer);
     }

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/DomainMutationImpl.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/DomainMutationImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2022 Expedia, Inc.
+ * Copyright (C) 2018-2024 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import com.expediagroup.streamplatform.streamregistry.model.Domain;
 @Component
 @RequiredArgsConstructor
 public class DomainMutationImpl implements DomainMutation {
+
   private final DomainService domainService;
   private final DomainView domainView;
 

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/InfrastructureMutationImpl.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/InfrastructureMutationImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2021 Expedia, Inc.
+ * Copyright (C) 2018-2024 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import com.expediagroup.streamplatform.streamregistry.model.Infrastructure;
 @Component
 @RequiredArgsConstructor
 public class InfrastructureMutationImpl implements InfrastructureMutation {
+
   private final InfrastructureService infrastructureService;
   private final InfrastructureView infrastructureView;
 

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ProducerBindingMutationImpl.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ProducerBindingMutationImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2021 Expedia, Inc.
+ * Copyright (C) 2018-2024 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,12 @@ import static com.expediagroup.streamplatform.streamregistry.graphql.StateHelper
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.expediagroup.streamplatform.streamregistry.core.services.ProducerBindingService;
 import com.expediagroup.streamplatform.streamregistry.core.views.ProducerBindingView;
+import com.expediagroup.streamplatform.streamregistry.graphql.StateHelper;
 import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.ProducerBindingKeyInput;
 import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.SpecificationInput;
 import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.StatusInput;
@@ -32,6 +34,10 @@ import com.expediagroup.streamplatform.streamregistry.model.ProducerBinding;
 @Component
 @RequiredArgsConstructor
 public class ProducerBindingMutationImpl implements ProducerBindingMutation {
+
+  @Value("${entityView.exist.check.enabled:true}")
+  private boolean checkExistEnabled;
+
   private final ProducerBindingService producerBindingService;
   private final ProducerBindingView producerBindingView;
 
@@ -57,7 +63,12 @@ public class ProducerBindingMutationImpl implements ProducerBindingMutation {
 
   @Override
   public Boolean delete(ProducerBindingKeyInput key) {
-    producerBindingView.get(key.asProducerBindingKey()).ifPresent(producerBindingService::delete);
+    if(checkExistEnabled){
+      producerBindingView.get(key.asProducerBindingKey()).ifPresent(producerBindingService::delete);
+    }else{
+      ProducerBinding producerBinding = new ProducerBinding(key.asProducerBindingKey(), StateHelper.specification(), StateHelper.status());
+      producerBindingService.delete(producerBinding);
+    }
     return true;
   }
 

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ProducerBindingMutationImpl.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ProducerBindingMutationImpl.java
@@ -63,9 +63,9 @@ public class ProducerBindingMutationImpl implements ProducerBindingMutation {
 
   @Override
   public Boolean delete(ProducerBindingKeyInput key) {
-    if(checkExistEnabled){
+    if (checkExistEnabled) {
       producerBindingView.get(key.asProducerBindingKey()).ifPresent(producerBindingService::delete);
-    }else{
+    } else {
       ProducerBinding producerBinding = new ProducerBinding(key.asProducerBindingKey(), StateHelper.specification(), StateHelper.status());
       producerBindingService.delete(producerBinding);
     }

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ProducerMutationImpl.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ProducerMutationImpl.java
@@ -31,7 +31,6 @@ import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.Statu
 import com.expediagroup.streamplatform.streamregistry.graphql.mutation.ProducerMutation;
 import com.expediagroup.streamplatform.streamregistry.model.Producer;
 
-
 @Component
 @RequiredArgsConstructor
 public class ProducerMutationImpl implements ProducerMutation {
@@ -64,9 +63,9 @@ public class ProducerMutationImpl implements ProducerMutation {
 
   @Override
   public Boolean delete(ProducerKeyInput key) {
-    if(checkExistEnabled){
+    if (checkExistEnabled) {
       producerView.get(key.asProducerKey()).ifPresent(producerService::delete);
-    }else{
+    } else {
       Producer producer = new Producer(key.asProducerKey(), StateHelper.specification(), StateHelper.status());
       producerService.delete(producer);
     }

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/SchemaMutationImpl.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/SchemaMutationImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2021 Expedia, Inc.
+ * Copyright (C) 2018-2024 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,10 @@ import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.Statu
 import com.expediagroup.streamplatform.streamregistry.graphql.mutation.SchemaMutation;
 import com.expediagroup.streamplatform.streamregistry.model.Schema;
 
-
 @Component
 @RequiredArgsConstructor
 public class SchemaMutationImpl implements SchemaMutation {
+
   private final SchemaService schemaService;
   private final SchemaView schemaView;
 

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/StreamBindingMutationImpl.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/StreamBindingMutationImpl.java
@@ -63,9 +63,9 @@ public class StreamBindingMutationImpl implements StreamBindingMutation {
 
   @Override
   public Boolean delete(StreamBindingKeyInput key) {
-    if(checkExistEnabled){
+    if (checkExistEnabled) {
       streamBindingView.get(key.asStreamBindingKey()).ifPresent(streamBindingService::delete);
-    }else{
+    } else {
       StreamBinding streamBinding = new StreamBinding(key.asStreamBindingKey(), StateHelper.specification(), StateHelper.status());
       streamBindingService.delete(streamBinding);
     }

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/StreamMutationImpl.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/StreamMutationImpl.java
@@ -66,9 +66,9 @@ public class StreamMutationImpl implements StreamMutation {
 
   @Override
   public Boolean delete(StreamKeyInput key) {
-    if(checkExistEnabled){
+    if (checkExistEnabled) {
       streamView.get(key.asStreamKey()).ifPresent(streamService::delete);
-    }else{
+    } else {
       Stream stream = new Stream(key.asStreamKey(), StateHelper.schemaKey(), StateHelper.specification(), StateHelper.status());
       streamService.delete(stream);
     }
@@ -85,7 +85,7 @@ public class StreamMutationImpl implements StreamMutation {
     Stream stream = new Stream();
     stream.setKey(key.asStreamKey());
     stream.setSpecification(specification.asSpecification());
-    if(schema.isPresent()) {
+    if (schema.isPresent()) {
       stream.setSchemaKey(schema.get().asSchemaKey());
     }
     maintainState(stream, streamView.get(stream.getKey()));

--- a/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ConsumerBindingMutationImplTest.java
+++ b/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ConsumerBindingMutationImplTest.java
@@ -15,6 +15,7 @@
  */
 package com.expediagroup.streamplatform.streamregistry.graphql.mutation.impl;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -52,14 +53,25 @@ public class ConsumerBindingMutationImplTest {
   }
 
   @Test
-  public void deleteWithCheckExistEnabled() {
+  public void deleteWithCheckExistEnabledWhenEntityExists() {
     ReflectionTestUtils.setField(consumerBindingMutation, "checkExistEnabled", true);
     ConsumerBindingKeyInput key = getConsumerBindingInputKey();
     when(consumerBindingView.get(any())).thenReturn(Optional.of(getConsumer(key)));
     Boolean result = consumerBindingMutation.delete(key);
     verify(consumerBindingService, times(1)).delete(any());
     verify(consumerBindingView, times(1)).get(any());
-    assert (result);
+    assertTrue(result);
+  }
+
+  @Test
+  public void deleteWithCheckExistEnabledWhenEntityDoesNotExist() {
+    ReflectionTestUtils.setField(consumerBindingMutation, "checkExistEnabled", true);
+    ConsumerBindingKeyInput key = getConsumerBindingInputKey();
+    when(consumerBindingView.get(any())).thenReturn(Optional.empty());
+    Boolean result = consumerBindingMutation.delete(key);
+    verify(consumerBindingService, times(0)).delete(any());
+    verify(consumerBindingView, times(1)).get(any());
+    assertTrue(result);
   }
 
   @Test
@@ -69,7 +81,7 @@ public class ConsumerBindingMutationImplTest {
     Boolean result = consumerBindingMutation.delete(key);
     verify(consumerBindingService, times(1)).delete(getConsumer(key));
     verify(consumerBindingView, times(0)).get(any());
-    assert (result);
+    assertTrue(result);
   }
 
   private ConsumerBindingKeyInput getConsumerBindingInputKey() {

--- a/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ConsumerBindingMutationImplTest.java
+++ b/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ConsumerBindingMutationImplTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2018-2024 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.streamplatform.streamregistry.graphql.mutation.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.expediagroup.streamplatform.streamregistry.core.services.ConsumerBindingService;
+import com.expediagroup.streamplatform.streamregistry.core.views.ConsumerBindingView;
+import com.expediagroup.streamplatform.streamregistry.graphql.StateHelper;
+import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.ConsumerBindingKeyInput;
+import com.expediagroup.streamplatform.streamregistry.model.ConsumerBinding;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConsumerBindingMutationImplTest {
+
+  @Mock
+  private ConsumerBindingService consumerBindingService;
+
+  @Mock
+  private ConsumerBindingView consumerBindingView;
+
+  private ConsumerBindingMutationImpl consumerBindingMutation;
+
+  @Before
+  public void before() throws Exception {
+    consumerBindingMutation = new ConsumerBindingMutationImpl(consumerBindingService, consumerBindingView);
+  }
+
+  @Test
+  public void deleteWithCheckExistEnabled() {
+    ReflectionTestUtils.setField(consumerBindingMutation, "checkExistEnabled", true);
+    ConsumerBindingKeyInput key = getConsumerBindingInputKey();
+    when(consumerBindingView.get(any())).thenReturn(Optional.of(getConsumer(key)));
+    Boolean result = consumerBindingMutation.delete(key);
+    verify(consumerBindingService, times(1)).delete(any());
+    verify(consumerBindingView, times(1)).get(any());
+    assert (result);
+  }
+
+  @Test
+  public void deleteWithCheckExistDisabled() {
+    ReflectionTestUtils.setField(consumerBindingMutation, "checkExistEnabled", false);
+    ConsumerBindingKeyInput key = getConsumerBindingInputKey();
+    Boolean result = consumerBindingMutation.delete(key);
+    verify(consumerBindingService, times(1)).delete(getConsumer(key));
+    verify(consumerBindingView, times(0)).get(any());
+    assert (result);
+  }
+
+  private ConsumerBindingKeyInput getConsumerBindingInputKey() {
+    return ConsumerBindingKeyInput.builder()
+      .streamDomain("domain")
+      .streamName("stream")
+      .streamVersion(1)
+      .infrastructureZone("zone")
+      .infrastructureName("infrastructure")
+      .consumerName("consumer")
+      .build();
+  }
+
+  private ConsumerBinding getConsumer(ConsumerBindingKeyInput key) {
+    return new ConsumerBinding(key.asConsumerBindingKey(), StateHelper.specification(), StateHelper.status());
+  }
+}

--- a/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ConsumerMutationImplTest.java
+++ b/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ConsumerMutationImplTest.java
@@ -15,6 +15,7 @@
  */
 package com.expediagroup.streamplatform.streamregistry.graphql.mutation.impl;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -52,14 +53,25 @@ public class ConsumerMutationImplTest {
   }
 
   @Test
-  public void deleteWithCheckExistEnabled() {
+  public void deleteWithCheckExistEnabledWhenEntityExists() {
     ReflectionTestUtils.setField(consumerMutation, "checkExistEnabled", true);
     ConsumerKeyInput key = getConsumerInputKey();
     when(consumerView.get(any())).thenReturn(Optional.of(getConsumer(key)));
     Boolean result = consumerMutation.delete(key);
     verify(consumerService, times(1)).delete(any());
     verify(consumerView, times(1)).get(any());
-    assert (result);
+    assertTrue(result);
+  }
+
+  @Test
+  public void deleteWithCheckExistEnabledWhenEntityDoesNotExist() {
+    ReflectionTestUtils.setField(consumerMutation, "checkExistEnabled", true);
+    ConsumerKeyInput key = getConsumerInputKey();
+    when(consumerView.get(any())).thenReturn(Optional.empty());
+    Boolean result = consumerMutation.delete(key);
+    verify(consumerService, times(0)).delete(any());
+    verify(consumerView, times(1)).get(any());
+    assertTrue(result);
   }
 
   @Test
@@ -69,7 +81,7 @@ public class ConsumerMutationImplTest {
     Boolean result = consumerMutation.delete(key);
     verify(consumerService, times(1)).delete(getConsumer(key));
     verify(consumerView, times(0)).get(any());
-    assert (result);
+    assertTrue(result);
   }
 
   private ConsumerKeyInput getConsumerInputKey() {

--- a/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ConsumerMutationImplTest.java
+++ b/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ConsumerMutationImplTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2018-2024 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.streamplatform.streamregistry.graphql.mutation.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.expediagroup.streamplatform.streamregistry.core.services.ConsumerService;
+import com.expediagroup.streamplatform.streamregistry.core.views.ConsumerView;
+import com.expediagroup.streamplatform.streamregistry.graphql.StateHelper;
+import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.ConsumerKeyInput;
+import com.expediagroup.streamplatform.streamregistry.model.Consumer;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConsumerMutationImplTest {
+
+  @Mock
+  private ConsumerService consumerService;
+
+  @Mock
+  private ConsumerView consumerView;
+
+  private ConsumerMutationImpl consumerMutation;
+
+  @Before
+  public void before() throws Exception {
+    consumerMutation = new ConsumerMutationImpl(consumerService, consumerView);
+  }
+
+  @Test
+  public void deleteWithCheckExistEnabled() {
+    ReflectionTestUtils.setField(consumerMutation, "checkExistEnabled", true);
+    ConsumerKeyInput key = getConsumerInputKey();
+    when(consumerView.get(any())).thenReturn(Optional.of(getConsumer(key)));
+    Boolean result = consumerMutation.delete(key);
+    verify(consumerService, times(1)).delete(any());
+    verify(consumerView, times(1)).get(any());
+    assert (result);
+  }
+
+  @Test
+  public void deleteWithCheckExistDisabled() {
+    ReflectionTestUtils.setField(consumerMutation, "checkExistEnabled", false);
+    ConsumerKeyInput key = getConsumerInputKey();
+    Boolean result = consumerMutation.delete(key);
+    verify(consumerService, times(1)).delete(getConsumer(key));
+    verify(consumerView, times(0)).get(any());
+    assert (result);
+  }
+
+  private ConsumerKeyInput getConsumerInputKey() {
+    return ConsumerKeyInput.builder()
+      .streamDomain("domain")
+      .streamName("stream")
+      .streamVersion(1)
+      .zone("zone")
+      .name("consumer")
+      .build();
+  }
+
+  private Consumer getConsumer(ConsumerKeyInput key) {
+    return new Consumer(key.asConsumerKey(), StateHelper.specification(), StateHelper.status());
+  }
+}

--- a/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ProducerBindingMutationImplTest.java
+++ b/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ProducerBindingMutationImplTest.java
@@ -15,6 +15,7 @@
  */
 package com.expediagroup.streamplatform.streamregistry.graphql.mutation.impl;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -52,14 +53,25 @@ public class ProducerBindingMutationImplTest {
   }
 
   @Test
-  public void deleteWithCheckExistEnabled() {
+  public void deleteWithCheckExistEnabledWhenEntityExists() {
     ReflectionTestUtils.setField(consumerBindingMutation, "checkExistEnabled", true);
     ConsumerBindingKeyInput key = getConsumerBindingInputKey();
     when(consumerBindingView.get(any())).thenReturn(Optional.of(getConsumer(key)));
     Boolean result = consumerBindingMutation.delete(key);
     verify(consumerBindingService, times(1)).delete(any());
     verify(consumerBindingView, times(1)).get(any());
-    assert (result);
+    assertTrue(result);
+  }
+
+  @Test
+  public void deleteWithCheckExistEnabledWhenEntityDoesNotExist() {
+    ReflectionTestUtils.setField(consumerBindingMutation, "checkExistEnabled", true);
+    ConsumerBindingKeyInput key = getConsumerBindingInputKey();
+    when(consumerBindingView.get(any())).thenReturn(Optional.empty());
+    Boolean result = consumerBindingMutation.delete(key);
+    verify(consumerBindingService, times(0)).delete(any());
+    verify(consumerBindingView, times(1)).get(any());
+    assertTrue(result);
   }
 
   @Test
@@ -69,7 +81,7 @@ public class ProducerBindingMutationImplTest {
     Boolean result = consumerBindingMutation.delete(key);
     verify(consumerBindingService, times(1)).delete(getConsumer(key));
     verify(consumerBindingView, times(0)).get(any());
-    assert (result);
+    assertTrue(result);
   }
 
   private ConsumerBindingKeyInput getConsumerBindingInputKey() {

--- a/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ProducerBindingMutationImplTest.java
+++ b/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ProducerBindingMutationImplTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2018-2024 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.streamplatform.streamregistry.graphql.mutation.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.expediagroup.streamplatform.streamregistry.core.services.ConsumerBindingService;
+import com.expediagroup.streamplatform.streamregistry.core.views.ConsumerBindingView;
+import com.expediagroup.streamplatform.streamregistry.graphql.StateHelper;
+import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.ConsumerBindingKeyInput;
+import com.expediagroup.streamplatform.streamregistry.model.ConsumerBinding;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProducerBindingMutationImplTest {
+
+  @Mock
+  private ConsumerBindingService consumerBindingService;
+
+  @Mock
+  private ConsumerBindingView consumerBindingView;
+
+  private ConsumerBindingMutationImpl consumerBindingMutation;
+
+  @Before
+  public void before() throws Exception {
+    consumerBindingMutation = new ConsumerBindingMutationImpl(consumerBindingService, consumerBindingView);
+  }
+
+  @Test
+  public void deleteWithCheckExistEnabled() {
+    ReflectionTestUtils.setField(consumerBindingMutation, "checkExistEnabled", true);
+    ConsumerBindingKeyInput key = getConsumerBindingInputKey();
+    when(consumerBindingView.get(any())).thenReturn(Optional.of(getConsumer(key)));
+    Boolean result = consumerBindingMutation.delete(key);
+    verify(consumerBindingService, times(1)).delete(any());
+    verify(consumerBindingView, times(1)).get(any());
+    assert (result);
+  }
+
+  @Test
+  public void deleteWithCheckExistDisabled() {
+    ReflectionTestUtils.setField(consumerBindingMutation, "checkExistEnabled", false);
+    ConsumerBindingKeyInput key = getConsumerBindingInputKey();
+    Boolean result = consumerBindingMutation.delete(key);
+    verify(consumerBindingService, times(1)).delete(getConsumer(key));
+    verify(consumerBindingView, times(0)).get(any());
+    assert (result);
+  }
+
+  private ConsumerBindingKeyInput getConsumerBindingInputKey() {
+    return ConsumerBindingKeyInput.builder()
+      .streamDomain("domain")
+      .streamName("stream")
+      .streamVersion(1)
+      .infrastructureZone("zone")
+      .infrastructureName("infrastructure")
+      .consumerName("consumer")
+      .build();
+  }
+
+  private ConsumerBinding getConsumer(ConsumerBindingKeyInput key) {
+    return new ConsumerBinding(key.asConsumerBindingKey(), StateHelper.specification(), StateHelper.status());
+  }
+}

--- a/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ProducerMutationImplTest.java
+++ b/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ProducerMutationImplTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2018-2024 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.streamplatform.streamregistry.graphql.mutation.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.expediagroup.streamplatform.streamregistry.core.services.ProducerService;
+import com.expediagroup.streamplatform.streamregistry.core.views.ProducerView;
+import com.expediagroup.streamplatform.streamregistry.graphql.StateHelper;
+import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.ProducerKeyInput;
+import com.expediagroup.streamplatform.streamregistry.model.Producer;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProducerMutationImplTest {
+
+  @Mock
+  private ProducerService producerService;
+
+  @Mock
+  private ProducerView producerView;
+
+  private ProducerMutationImpl producerMutation;
+
+  @Before
+  public void before() throws Exception {
+    producerMutation = new ProducerMutationImpl(producerService, producerView);
+  }
+
+  @Test
+  public void deleteWithCheckExistEnabled() {
+    ReflectionTestUtils.setField(producerMutation, "checkExistEnabled", true);
+    ProducerKeyInput key = getProducerInputKey();
+    when(producerView.get(any())).thenReturn(Optional.of(getProducer(key)));
+    Boolean result = producerMutation.delete(key);
+    verify(producerService, times(1)).delete(any());
+    verify(producerView, times(1)).get(any());
+    assert (result);
+  }
+
+  @Test
+  public void deleteWithCheckExistDisabled() {
+    ProducerMutationImpl producerMutation = new ProducerMutationImpl(producerService, producerView);
+    ReflectionTestUtils.setField(producerMutation, "checkExistEnabled", false);
+    ProducerKeyInput key = getProducerInputKey();
+    Boolean result = producerMutation.delete(key);
+    verify(producerService, times(1)).delete(getProducer(key));
+    verify(producerView, times(0)).get(any());
+    assert (result);
+  }
+
+  private ProducerKeyInput getProducerInputKey() {
+    return ProducerKeyInput.builder()
+      .streamDomain("domain")
+      .streamName("stream")
+      .streamVersion(1)
+      .zone("zone")
+      .name("producer")
+      .build();
+  }
+
+  private Producer getProducer(ProducerKeyInput key) {
+    return new Producer(key.asProducerKey(), StateHelper.specification(), StateHelper.status());
+  }
+}

--- a/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ProducerMutationImplTest.java
+++ b/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/ProducerMutationImplTest.java
@@ -15,6 +15,7 @@
  */
 package com.expediagroup.streamplatform.streamregistry.graphql.mutation.impl;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -52,14 +53,25 @@ public class ProducerMutationImplTest {
   }
 
   @Test
-  public void deleteWithCheckExistEnabled() {
+  public void deleteWithCheckExistEnabledWhenEntityExists() {
     ReflectionTestUtils.setField(producerMutation, "checkExistEnabled", true);
     ProducerKeyInput key = getProducerInputKey();
     when(producerView.get(any())).thenReturn(Optional.of(getProducer(key)));
     Boolean result = producerMutation.delete(key);
     verify(producerService, times(1)).delete(any());
     verify(producerView, times(1)).get(any());
-    assert (result);
+    assertTrue(result);
+  }
+
+  @Test
+  public void deleteWithCheckExistEnabledWhenEntityDoesNotExist() {
+    ReflectionTestUtils.setField(producerMutation, "checkExistEnabled", true);
+    ProducerKeyInput key = getProducerInputKey();
+    when(producerView.get(any())).thenReturn(Optional.empty());
+    Boolean result = producerMutation.delete(key);
+    verify(producerService, times(0)).delete(any());
+    verify(producerView, times(1)).get(any());
+    assertTrue(result);
   }
 
   @Test
@@ -70,7 +82,7 @@ public class ProducerMutationImplTest {
     Boolean result = producerMutation.delete(key);
     verify(producerService, times(1)).delete(getProducer(key));
     verify(producerView, times(0)).get(any());
-    assert (result);
+    assertTrue(result);
   }
 
   private ProducerKeyInput getProducerInputKey() {

--- a/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/StreamBindingMutationImplTest.java
+++ b/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/StreamBindingMutationImplTest.java
@@ -15,6 +15,7 @@
  */
 package com.expediagroup.streamplatform.streamregistry.graphql.mutation.impl;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -52,14 +53,25 @@ public class StreamBindingMutationImplTest {
   }
 
   @Test
-  public void deleteWithCheckExistEnabled() {
+  public void deleteWithCheckExistEnabledWhenEntityExists() {
     ReflectionTestUtils.setField(streamBindingMutation, "checkExistEnabled", true);
     StreamBindingKeyInput key = getStreamBindingInputKey();
     when(streamBindingView.get(any())).thenReturn(Optional.of(getStream(key)));
     Boolean result = streamBindingMutation.delete(key);
     verify(streamBindingService, times(1)).delete(any());
     verify(streamBindingView, times(1)).get(any());
-    assert (result);
+    assertTrue(result);
+  }
+
+  @Test
+  public void deleteWithCheckExistEnabledWhenEntityDoesNotExist() {
+    ReflectionTestUtils.setField(streamBindingMutation, "checkExistEnabled", true);
+    StreamBindingKeyInput key = getStreamBindingInputKey();
+    when(streamBindingView.get(any())).thenReturn(Optional.empty());
+    Boolean result = streamBindingMutation.delete(key);
+    verify(streamBindingService, times(0)).delete(any());
+    verify(streamBindingView, times(1)).get(any());
+    assertTrue(result);
   }
 
   @Test
@@ -69,7 +81,7 @@ public class StreamBindingMutationImplTest {
     Boolean result = streamBindingMutation.delete(key);
     verify(streamBindingService, times(1)).delete(getStream(key));
     verify(streamBindingView, times(0)).get(any());
-    assert (result);
+    assertTrue(result);
   }
 
   private StreamBindingKeyInput getStreamBindingInputKey() {

--- a/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/StreamBindingMutationImplTest.java
+++ b/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/StreamBindingMutationImplTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2018-2024 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.streamplatform.streamregistry.graphql.mutation.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.expediagroup.streamplatform.streamregistry.core.services.StreamBindingService;
+import com.expediagroup.streamplatform.streamregistry.core.views.StreamBindingView;
+import com.expediagroup.streamplatform.streamregistry.graphql.StateHelper;
+import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.StreamBindingKeyInput;
+import com.expediagroup.streamplatform.streamregistry.model.StreamBinding;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StreamBindingMutationImplTest {
+
+  @Mock
+  private StreamBindingService streamBindingService;
+
+  @Mock
+  private StreamBindingView streamBindingView;
+
+  private StreamBindingMutationImpl streamBindingMutation;
+
+  @Before
+  public void before() throws Exception {
+    streamBindingMutation = new StreamBindingMutationImpl(streamBindingService, streamBindingView);
+  }
+
+  @Test
+  public void deleteWithCheckExistEnabled() {
+    ReflectionTestUtils.setField(streamBindingMutation, "checkExistEnabled", true);
+    StreamBindingKeyInput key = getStreamBindingInputKey();
+    when(streamBindingView.get(any())).thenReturn(Optional.of(getStream(key)));
+    Boolean result = streamBindingMutation.delete(key);
+    verify(streamBindingService, times(1)).delete(any());
+    verify(streamBindingView, times(1)).get(any());
+    assert (result);
+  }
+
+  @Test
+  public void deleteWithCheckExistDisabled() {
+    ReflectionTestUtils.setField(streamBindingMutation, "checkExistEnabled", false);
+    StreamBindingKeyInput key = getStreamBindingInputKey();
+    Boolean result = streamBindingMutation.delete(key);
+    verify(streamBindingService, times(1)).delete(getStream(key));
+    verify(streamBindingView, times(0)).get(any());
+    assert (result);
+  }
+
+  private StreamBindingKeyInput getStreamBindingInputKey() {
+    return StreamBindingKeyInput.builder()
+      .streamDomain("domain")
+      .streamName("stream")
+      .streamVersion(1)
+      .infrastructureZone("zone")
+      .infrastructureName("infrastructure")
+      .build();
+  }
+
+  private StreamBinding getStream(StreamBindingKeyInput key) {
+    return new StreamBinding(key.asStreamBindingKey(), StateHelper.specification(), StateHelper.status());
+  }
+}

--- a/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/StreamMutationImplTest.java
+++ b/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/StreamMutationImplTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2018-2024 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.streamplatform.streamregistry.graphql.mutation.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.expediagroup.streamplatform.streamregistry.core.services.StreamService;
+import com.expediagroup.streamplatform.streamregistry.core.views.StreamView;
+import com.expediagroup.streamplatform.streamregistry.graphql.StateHelper;
+import com.expediagroup.streamplatform.streamregistry.graphql.model.inputs.StreamKeyInput;
+import com.expediagroup.streamplatform.streamregistry.model.Stream;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StreamMutationImplTest {
+
+  @Mock
+  private StreamService streamService;
+
+  @Mock
+  private StreamView streamView;
+  private StreamMutationImpl streamMutation;
+
+  @Before
+  public void before() throws Exception {
+    streamMutation = new StreamMutationImpl(streamService, streamView);
+  }
+
+  @Test
+  public void deleteWithCheckExistEnabled() {
+    ReflectionTestUtils.setField(streamMutation, "checkExistEnabled", true);
+    StreamKeyInput key = getStreamInputKey();
+    when(streamView.get(any())).thenReturn(Optional.of(getStream(key)));
+    Boolean result = streamMutation.delete(key);
+    verify(streamService, times(1)).delete(any());
+    verify(streamView, times(1)).get(any());
+    assert (result);
+  }
+
+  @Test
+  public void deleteWithCheckExistDisabled() {
+    ReflectionTestUtils.setField(streamMutation, "checkExistEnabled", false);
+    StreamKeyInput key = getStreamInputKey();
+    Boolean result = streamMutation.delete(key);
+    verify(streamService, times(1)).delete(getStream(key));
+    verify(streamView, times(0)).get(any());
+    assert (result);
+  }
+
+  private StreamKeyInput getStreamInputKey() {
+    return StreamKeyInput.builder()
+      .domain("domain")
+      .name("name")
+      .version(1)
+      .build();
+  }
+
+  private Stream getStream(StreamKeyInput key) {
+    return new Stream(key.asStreamKey(), StateHelper.schemaKey(), StateHelper.specification(), StateHelper.status());
+  }
+}

--- a/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/StreamMutationImplTest.java
+++ b/graphql/api/src/test/java/com/expediagroup/streamplatform/streamregistry/graphql/mutation/impl/StreamMutationImplTest.java
@@ -15,6 +15,7 @@
  */
 package com.expediagroup.streamplatform.streamregistry.graphql.mutation.impl;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -51,14 +52,25 @@ public class StreamMutationImplTest {
   }
 
   @Test
-  public void deleteWithCheckExistEnabled() {
+  public void deleteWithCheckExistEnabledWhenEntityExists() {
     ReflectionTestUtils.setField(streamMutation, "checkExistEnabled", true);
     StreamKeyInput key = getStreamInputKey();
     when(streamView.get(any())).thenReturn(Optional.of(getStream(key)));
     Boolean result = streamMutation.delete(key);
     verify(streamService, times(1)).delete(any());
     verify(streamView, times(1)).get(any());
-    assert (result);
+    assertTrue(result);
+  }
+
+  @Test
+  public void deleteWithCheckExistEnabledWhenEntityDoesNotExist() {
+    ReflectionTestUtils.setField(streamMutation, "checkExistEnabled", true);
+    StreamKeyInput key = getStreamInputKey();
+    when(streamView.get(any())).thenReturn(Optional.empty());
+    Boolean result = streamMutation.delete(key);
+    verify(streamService, times(0)).delete(any());
+    verify(streamView, times(1)).get(any());
+    assertTrue(result);
   }
 
   @Test
@@ -68,7 +80,7 @@ public class StreamMutationImplTest {
     Boolean result = streamMutation.delete(key);
     verify(streamService, times(1)).delete(getStream(key));
     verify(streamView, times(0)).get(any());
-    assert (result);
+    assertTrue(result);
   }
 
   private StreamKeyInput getStreamInputKey() {


### PR DESCRIPTION
Configurable property to enable or disable checking if entity exists in EntityView during delete.
We need a way of servicing deletes when the EntityView thinks they are already deleted.

Details

Currently, the OSS project will not allow us to delete entities that don't exist in the EntityView. For example, the implementation of delete from ConsumerMutationImpl includes an ifPresent check:

```
@Override
  public Boolean delete(ConsumerKeyInput key) {
    consumerView.get(key.asConsumerKey()).ifPresent(consumerService::delete);
    return true;
  }
```
  
Eg: When no tombstone for the original schema key id during handling of double delete events, the identified entities will not exist in the EntityView and hence it will be impossible to delete them.


Changed
entityView.exist.check.enabled property to decide if entity exists in EntityView during delete operation.


# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
