### PR TITLE
fix: handling delete entity events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+### Fixed
+- Using egsp.kafka type to resolve handler for deletion of stream, consumer, consumer binding, producer, producer binding and stream binding entities. 
 
 ## [2.2.0] 2023-01-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-### Fixed
+### Bugfix
 - Using egsp.kafka type to resolve handler for deletion of stream, consumer, consumer binding, producer, producer binding and stream binding entities. 
 
 ## [2.2.0] 2023-01-24

--- a/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/StateHelper.java
+++ b/graphql/api/src/main/java/com/expediagroup/streamplatform/streamregistry/graphql/StateHelper.java
@@ -40,7 +40,7 @@ public class StateHelper {
     return SpecificationInput.builder()
       .description("description")
       .tags(Collections.emptyList())
-      .type("default")
+      .type("egsp.kafka")
       .configuration(mapper.createObjectNode())
       .security(Collections.emptyList())
       .build().asSpecification();


### PR DESCRIPTION
# stream-registry PR

### Changed
* Using egsp.kafka type to resolve handler for deletion of stream, consumer, consumer binding, producer, producer binding and stream binding entities.

# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
