### PR TITLE
fix: STREAMP-15103: Add retries for KafkaEventReceiver to handle tran…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] 2025-06-16
+### Bugfix
+- Add retries for `KafkaEventReceiver` to handle transient start up error when consuming events from the repository topic.
+
+## [3.1.0] 2024-12-09
+### Accidental release.
+
 ## [3.0.2] 2025-01-29
 ### Reverted
 - Reverted the change in 3.0.1, this change would have adverse effects on too many existing schemas.

--- a/state/kafka-receiver/src/main/java/com/expediagroup/streamplatform/streamregistry/state/kafka/KafkaEventReceiver.java
+++ b/state/kafka-receiver/src/main/java/com/expediagroup/streamplatform/streamregistry/state/kafka/KafkaEventReceiver.java
@@ -140,9 +140,21 @@ public class KafkaEventReceiver implements EventReceiver {
     val topicPartition = new TopicPartition(config.getTopic(), 0);
     val topicPartitions = Collections.singletonList(topicPartition);
 
-    int partitions = consumer.partitionsFor(topicPartition.topic()).size();
-    if (partitions != 1) {
-      throw new IllegalStateException("Unsupported partition count. Require 1, got " + partitions);
+    int partitions = 0;
+    int count = 0;
+    while (partitions != 1) {
+      if (count > 3) {
+        throw new IllegalStateException("Unsupported partition count. Require 1, got " + partitions);
+      }
+      try {
+        Thread.sleep(5000 * count);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      count++;
+
+      partitions = consumer.partitionsFor(topicPartition.topic()).size();
+      log.info("Partition count is {} for topic {}", partitions, topicPartition.topic());
     }
 
     long beginningOffset = consumer.beginningOffsets(topicPartitions).get(topicPartition);


### PR DESCRIPTION
…sient start up error when consuming events from the repository topic.

# stream-registry PR

_&lt;High level description of the PR&gt;_

### Added
* _&lt;detail item of what was added&gt;_
* _&lt;describe functionality added&gt;_

### Changed
* _&lt;detail item of what was changed&gt;_
* _&lt;describe functionality that was changed&gt;
* _&lt;in particular, describe BACKWARD INCOMPATIBLE changes&gt;

### Deleted
* _&lt;detail item of what was removed&gt;_


# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation) 
